### PR TITLE
[add]抽選済み番号一覧コンポーネントの作成

### DIFF
--- a/view-user/src/components/common/BingoResult/BingoResult.module.css
+++ b/view-user/src/components/common/BingoResult/BingoResult.module.css
@@ -1,5 +1,5 @@
 .container {
-    height: 100vh;
+    /* height: 100vh; */
     width: 100vw;
     background-color: #C9AAAA;
     display: flex;
@@ -49,5 +49,5 @@
     font-size: 3rem;
     font-weight: bold;
     color:#D9D9D9;
-    box-shadow: 3px 3px 3px 3px #D9D9D9;
+    box-shadow: 3px 3px 3px 3px #A4A4A4;
   }

--- a/view-user/src/components/common/BingoResult/BingoResult.module.css
+++ b/view-user/src/components/common/BingoResult/BingoResult.module.css
@@ -1,0 +1,53 @@
+.container {
+    height: 100vh;
+    width: 100vw;
+    background-color: #C9AAAA;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .list_container {
+    height: 90vh;
+    width: 90vw;
+  }
+  
+  .card_frame {
+    border-radius: 3px;
+    border-width: 0px;
+    border-style: solid;
+    border-color: #333;
+    padding: 2rem;
+    background-color: #D9D9D9;
+  }
+
+  .card_text {
+    font-size: 3rem;
+    font-weight: bold;
+    color: #333;
+    padding-bottom: 10px;
+    padding-left: 10px;
+  }
+  
+  .card {
+    display: grid;
+    grid-template-columns: repeat(8, 1fr);
+    grid-gap: 10px;
+  }
+  
+  .card_content {
+    width: 150px;
+    height: 150px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: 3px;
+    border-width: 0px;
+    border-style: solid;
+    border-color: #333;
+    background-color: #C67979;
+    font-size: 3rem;
+    font-weight: bold;
+    color:#D9D9D9;
+    box-shadow: 3px 3px 3px 3px #D9D9D9;
+  }

--- a/view-user/src/components/common/BingoResult/BingoResult.module.css
+++ b/view-user/src/components/common/BingoResult/BingoResult.module.css
@@ -1,50 +1,50 @@
+.content_wrapper {
+  padding: 2rem;
+}
 
 .container {
-  margin: 2rem;
   border-radius: 3px;
   padding: 2rem;
-  background-color: #D9D9D9;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  background-color: #d9d9d9;
 }
 
 .frame_title {
-  font-size: 2rem;
+  /* font-size: clamp(下限, 可変, 上限)で動的に変わる */
+  font-size: clamp(12px, calc(100vw / 18 ) , 24px);
   font-weight: bold;
   color: #333;
-  padding-bottom: 1.5rem;
   padding-left: 10px;
 }
 
 .card_frame {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(150px, 100%), 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(25%, 150px), 2fr));
   gap: 16px;
 }
 
 .card {
-  height: 0;
-  padding-bottom: 100%;
+  height: auto;
+  aspect-ratio: 1 / 1;
   position: relative;
   border-radius: 3px;
-  border-width: 0px;
+  /* border-width: 0px;
   border-style: solid;
-  border-color: #333;
-  background-color: #C67979;
-  box-shadow: 3px 3px 3px 3px #A4A4A4;
+  border-color: #333; */
+  border: 0px solid #333;
+  background-color: #c67979;
+  box-shadow: 3px 3px 3px 3px #a4a4a4;
 }
 
 .card_content {
   width: 100%;
   height: 100%;
-  font-size: 3rem;
+  font-size: clamp(24px, calc(100vw / 9 ) , 96px);
   font-weight: bold;
-  color:#D9D9D9;
-}
-
-.card_content p {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  -webkit-transform: translate(-50%, -50%);
-  -ms-transform: translate(-50%, -50%);
+  color: #d9d9d9;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }

--- a/view-user/src/components/common/BingoResult/BingoResult.module.css
+++ b/view-user/src/components/common/BingoResult/BingoResult.module.css
@@ -1,53 +1,50 @@
+
 .container {
-    /* height: 100vh; */
-    width: 100vw;
-    background-color: #C9AAAA;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-  }
+  margin: 2rem;
+  border-radius: 3px;
+  padding: 2rem;
+  background-color: #D9D9D9;
+}
 
-  .list_container {
-    height: 90vh;
-    width: 90vw;
-  }
-  
-  .card_frame {
-    border-radius: 3px;
-    border-width: 0px;
-    border-style: solid;
-    border-color: #333;
-    padding: 2rem;
-    background-color: #D9D9D9;
-  }
+.frame_title {
+  font-size: 2rem;
+  font-weight: bold;
+  color: #333;
+  padding-bottom: 1.5rem;
+  padding-left: 10px;
+}
 
-  .card_text {
-    font-size: 3rem;
-    font-weight: bold;
-    color: #333;
-    padding-bottom: 10px;
-    padding-left: 10px;
-  }
-  
-  .card {
-    display: grid;
-    grid-template-columns: repeat(8, 1fr);
-    grid-gap: 10px;
-  }
-  
-  .card_content {
-    width: 150px;
-    height: 150px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    border-radius: 3px;
-    border-width: 0px;
-    border-style: solid;
-    border-color: #333;
-    background-color: #C67979;
-    font-size: 3rem;
-    font-weight: bold;
-    color:#D9D9D9;
-    box-shadow: 3px 3px 3px 3px #A4A4A4;
-  }
+.card_frame {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(150px, 100%), 1fr));
+  gap: 16px;
+}
+
+.card {
+  height: 0;
+  padding-bottom: 100%;
+  position: relative;
+  border-radius: 3px;
+  border-width: 0px;
+  border-style: solid;
+  border-color: #333;
+  background-color: #C67979;
+  box-shadow: 3px 3px 3px 3px #A4A4A4;
+}
+
+.card_content {
+  width: 100%;
+  height: 100%;
+  font-size: 3rem;
+  font-weight: bold;
+  color:#D9D9D9;
+}
+
+.card_content p {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  -webkit-transform: translate(-50%, -50%);
+  -ms-transform: translate(-50%, -50%);
+}

--- a/view-user/src/components/common/BingoResult/BingoResult.module.css
+++ b/view-user/src/components/common/BingoResult/BingoResult.module.css
@@ -21,7 +21,7 @@
 
 .card_frame {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(min(25%, 150px), 2fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(25%, 100px), 2fr));
   gap: 16px;
 }
 
@@ -30,18 +30,14 @@
   aspect-ratio: 1 / 1;
   position: relative;
   border-radius: 3px;
-  /* border-width: 0px;
-  border-style: solid;
-  border-color: #333; */
   border: 0px solid #333;
   background-color: #c67979;
   box-shadow: 3px 3px 3px 3px #a4a4a4;
 }
 
 .card_content {
-  width: 100%;
   height: 100%;
-  font-size: clamp(24px, calc(100vw / 9 ) , 96px);
+  font-size: clamp(24px, calc(100vw / 9 ) , 68px);
   font-weight: bold;
   color: #d9d9d9;
   display: flex;

--- a/view-user/src/components/common/BingoResult/BingoResult.tsx
+++ b/view-user/src/components/common/BingoResult/BingoResult.tsx
@@ -1,188 +1,25 @@
-import React from 'react'
-import { ReactNode } from "react"
-import styles from "./BingoResult.module.css"
+import React from "react";
+import { ReactNode } from "react";
+import styles from "./BingoResult.module.css";
 
 interface BingoResultProps {
-    dataArray: number[]
+  bingoResultNumber: number[];
 }
 
 export const BingoResult = (props: BingoResultProps) => {
   return (
-        <div className={styles.container}>
-          <p className={styles.frame_title}>抽選済み番号一覧</p>
-          <div className={styles.card_frame}>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[0]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[1]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[2]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[3]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[4]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[5]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[6]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[7]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[8]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[9]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[10]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[11]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[12]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[13]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[14]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[15]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[16]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[17]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[18]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[19]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[20]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[21]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[22]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[23]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[24]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[25]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[26]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[27]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[28]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[29]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[30]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[31]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[32]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[33]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[34]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[35]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[36]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[37]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[38]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[39]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[40]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[41]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[42]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[43]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[44]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[45]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[46]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[47]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[48]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[49]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[50]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[51]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[52]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[53]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[54]}</p></div>
-            </div>
-            <div className={styles.card}>
-              <div className={styles.card_content}><p>{props.dataArray[55]}</p></div>
-            </div>
+    <div className={styles.content_wrapper}>
+      <div className={styles.container}>
+        <div className={styles.frame_title}>抽選済み番号一覧</div>
+        <div className={styles.card_frame}>
+            {props.bingoResultNumber.map((num, index) => 
+              <div className={styles.card} key={index}>
+                <div className={styles.card_content}> {num}</div>
+              </div>)}
           </div>
         </div>
-
-  )
-}
+      </div>
+  );
+};
 
 export default BingoResult;

--- a/view-user/src/components/common/BingoResult/BingoResult.tsx
+++ b/view-user/src/components/common/BingoResult/BingoResult.tsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import { ReactNode } from "react"
+import styles from "./BingoResult.module.css"
+
+interface BingoResultProps {
+    dataArray: number[]
+}
+
+export const BingoResult = (props: BingoResultProps) => {
+  return (
+    <div className={styles.container}>
+      <div className={styles.list_container}>
+        <div className={styles.card_frame}>
+          <p className={styles.card_text}>抽選済み番号一覧</p>
+          <div className={styles.card}>
+            <div className={`${styles.card_content} ${styles._01}`}><p>{props.dataArray[0]}</p></div>
+            <div className={`${styles.card_content} ${styles._02}`}><p>{props.dataArray[1]}</p></div>
+            <div className={`${styles.card_content} ${styles._03}`}><p>{props.dataArray[2]}</p></div>
+            <div className={`${styles.card_content} ${styles._04}`}><p>{props.dataArray[3]}</p></div>
+            <div className={`${styles.card_content} ${styles._05}`}><p>{props.dataArray[4]}</p></div>
+            <div className={`${styles.card_content} ${styles._06}`}><p>{props.dataArray[5]}</p></div>
+            <div className={`${styles.card_content} ${styles._07}`}><p>{props.dataArray[6]}</p></div>
+            <div className={`${styles.card_content} ${styles._08}`}><p>{props.dataArray[7]}</p></div>
+            <div className={`${styles.card_content} ${styles._09}`}><p>{props.dataArray[8]}</p></div>
+            <div className={`${styles.card_content} ${styles._10}`}><p>{props.dataArray[9]}</p></div>
+            <div className={`${styles.card_content} ${styles._11}`}><p>{props.dataArray[10]}</p></div>
+            <div className={`${styles.card_content} ${styles._12}`}><p>{props.dataArray[11]}</p></div>
+            <div className={`${styles.card_content} ${styles._13}`}><p>{props.dataArray[12]}</p></div>
+            <div className={`${styles.card_content} ${styles._14}`}><p>{props.dataArray[13]}</p></div>
+            <div className={`${styles.card_content} ${styles._15}`}><p>{props.dataArray[14]}</p></div>
+            <div className={`${styles.card_content} ${styles._16}`}><p>{props.dataArray[15]}</p></div>
+            <div className={`${styles.card_content} ${styles._17}`}><p>{props.dataArray[16]}</p></div>
+            <div className={`${styles.card_content} ${styles._18}`}><p>{props.dataArray[17]}</p></div>
+            <div className={`${styles.card_content} ${styles._19}`}><p>{props.dataArray[18]}</p></div>
+            <div className={`${styles.card_content} ${styles._20}`}><p>{props.dataArray[19]}</p></div>
+            <div className={`${styles.card_content} ${styles._21}`}><p>{props.dataArray[20]}</p></div>
+            <div className={`${styles.card_content} ${styles._22}`}><p>{props.dataArray[21]}</p></div>
+            <div className={`${styles.card_content} ${styles._23}`}><p>{props.dataArray[22]}</p></div>
+            <div className={`${styles.card_content} ${styles._24}`}><p>{props.dataArray[23]}</p></div>
+            <div className={`${styles.card_content} ${styles._25}`}><p>{props.dataArray[24]}</p></div>
+            <div className={`${styles.card_content} ${styles._26}`}><p>{props.dataArray[25]}</p></div>
+            <div className={`${styles.card_content} ${styles._27}`}><p>{props.dataArray[26]}</p></div>
+            <div className={`${styles.card_content} ${styles._28}`}><p>{props.dataArray[27]}</p></div>
+            <div className={`${styles.card_content} ${styles._29}`}><p>{props.dataArray[28]}</p></div>
+            <div className={`${styles.card_content} ${styles._30}`}><p>{props.dataArray[29]}</p></div>
+            <div className={`${styles.card_content} ${styles._31}`}><p>{props.dataArray[30]}</p></div>
+            <div className={`${styles.card_content} ${styles._32}`}><p>{props.dataArray[31]}</p></div>
+            <div className={`${styles.card_content} ${styles._33}`}><p>{props.dataArray[32]}</p></div>
+            <div className={`${styles.card_content} ${styles._34}`}><p>{props.dataArray[33]}</p></div>
+            <div className={`${styles.card_content} ${styles._35}`}><p>{props.dataArray[34]}</p></div>
+            <div className={`${styles.card_content} ${styles._36}`}><p>{props.dataArray[35]}</p></div>
+            <div className={`${styles.card_content} ${styles._37}`}><p>{props.dataArray[36]}</p></div>
+            <div className={`${styles.card_content} ${styles._38}`}><p>{props.dataArray[37]}</p></div>
+            <div className={`${styles.card_content} ${styles._39}`}><p>{props.dataArray[38]}</p></div>
+            <div className={`${styles.card_content} ${styles._40}`}><p>{props.dataArray[39]}</p></div>
+            <div className={`${styles.card_content} ${styles._41}`}><p>{props.dataArray[40]}</p></div>
+            <div className={`${styles.card_content} ${styles._42}`}><p>{props.dataArray[41]}</p></div>
+            <div className={`${styles.card_content} ${styles._43}`}><p>{props.dataArray[42]}</p></div>
+            <div className={`${styles.card_content} ${styles._44}`}><p>{props.dataArray[43]}</p></div>
+            <div className={`${styles.card_content} ${styles._45}`}><p>{props.dataArray[44]}</p></div>
+            <div className={`${styles.card_content} ${styles._46}`}><p>{props.dataArray[45]}</p></div>
+            <div className={`${styles.card_content} ${styles._47}`}><p>{props.dataArray[46]}</p></div>
+            <div className={`${styles.card_content} ${styles._48}`}><p>{props.dataArray[47]}</p></div>
+            <div className={`${styles.card_content} ${styles._49}`}><p>{props.dataArray[48]}</p></div>
+            <div className={`${styles.card_content} ${styles._50}`}><p>{props.dataArray[49]}</p></div>
+            <div className={`${styles.card_content} ${styles._51}`}><p>{props.dataArray[50]}</p></div>
+            <div className={`${styles.card_content} ${styles._52}`}><p>{props.dataArray[51]}</p></div>
+            <div className={`${styles.card_content} ${styles._53}`}><p>{props.dataArray[52]}</p></div>
+            <div className={`${styles.card_content} ${styles._54}`}><p>{props.dataArray[53]}</p></div>
+            <div className={`${styles.card_content} ${styles._55}`}><p>{props.dataArray[54]}</p></div>
+            <div className={`${styles.card_content} ${styles._56}`}><p>{props.dataArray[55]}</p></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default BingoResult;

--- a/view-user/src/components/common/BingoResult/BingoResult.tsx
+++ b/view-user/src/components/common/BingoResult/BingoResult.tsx
@@ -8,71 +8,180 @@ interface BingoResultProps {
 
 export const BingoResult = (props: BingoResultProps) => {
   return (
-    <div className={styles.container}>
-      <div className={styles.list_container}>
-        <div className={styles.card_frame}>
-          <p className={styles.card_text}>抽選済み番号一覧</p>
-          <div className={styles.card}>
-            <div className={`${styles.card_content} ${styles._01}`}><p>{props.dataArray[0]}</p></div>
-            <div className={`${styles.card_content} ${styles._02}`}><p>{props.dataArray[1]}</p></div>
-            <div className={`${styles.card_content} ${styles._03}`}><p>{props.dataArray[2]}</p></div>
-            <div className={`${styles.card_content} ${styles._04}`}><p>{props.dataArray[3]}</p></div>
-            <div className={`${styles.card_content} ${styles._05}`}><p>{props.dataArray[4]}</p></div>
-            <div className={`${styles.card_content} ${styles._06}`}><p>{props.dataArray[5]}</p></div>
-            <div className={`${styles.card_content} ${styles._07}`}><p>{props.dataArray[6]}</p></div>
-            <div className={`${styles.card_content} ${styles._08}`}><p>{props.dataArray[7]}</p></div>
-            <div className={`${styles.card_content} ${styles._09}`}><p>{props.dataArray[8]}</p></div>
-            <div className={`${styles.card_content} ${styles._10}`}><p>{props.dataArray[9]}</p></div>
-            <div className={`${styles.card_content} ${styles._11}`}><p>{props.dataArray[10]}</p></div>
-            <div className={`${styles.card_content} ${styles._12}`}><p>{props.dataArray[11]}</p></div>
-            <div className={`${styles.card_content} ${styles._13}`}><p>{props.dataArray[12]}</p></div>
-            <div className={`${styles.card_content} ${styles._14}`}><p>{props.dataArray[13]}</p></div>
-            <div className={`${styles.card_content} ${styles._15}`}><p>{props.dataArray[14]}</p></div>
-            <div className={`${styles.card_content} ${styles._16}`}><p>{props.dataArray[15]}</p></div>
-            <div className={`${styles.card_content} ${styles._17}`}><p>{props.dataArray[16]}</p></div>
-            <div className={`${styles.card_content} ${styles._18}`}><p>{props.dataArray[17]}</p></div>
-            <div className={`${styles.card_content} ${styles._19}`}><p>{props.dataArray[18]}</p></div>
-            <div className={`${styles.card_content} ${styles._20}`}><p>{props.dataArray[19]}</p></div>
-            <div className={`${styles.card_content} ${styles._21}`}><p>{props.dataArray[20]}</p></div>
-            <div className={`${styles.card_content} ${styles._22}`}><p>{props.dataArray[21]}</p></div>
-            <div className={`${styles.card_content} ${styles._23}`}><p>{props.dataArray[22]}</p></div>
-            <div className={`${styles.card_content} ${styles._24}`}><p>{props.dataArray[23]}</p></div>
-            <div className={`${styles.card_content} ${styles._25}`}><p>{props.dataArray[24]}</p></div>
-            <div className={`${styles.card_content} ${styles._26}`}><p>{props.dataArray[25]}</p></div>
-            <div className={`${styles.card_content} ${styles._27}`}><p>{props.dataArray[26]}</p></div>
-            <div className={`${styles.card_content} ${styles._28}`}><p>{props.dataArray[27]}</p></div>
-            <div className={`${styles.card_content} ${styles._29}`}><p>{props.dataArray[28]}</p></div>
-            <div className={`${styles.card_content} ${styles._30}`}><p>{props.dataArray[29]}</p></div>
-            <div className={`${styles.card_content} ${styles._31}`}><p>{props.dataArray[30]}</p></div>
-            <div className={`${styles.card_content} ${styles._32}`}><p>{props.dataArray[31]}</p></div>
-            <div className={`${styles.card_content} ${styles._33}`}><p>{props.dataArray[32]}</p></div>
-            <div className={`${styles.card_content} ${styles._34}`}><p>{props.dataArray[33]}</p></div>
-            <div className={`${styles.card_content} ${styles._35}`}><p>{props.dataArray[34]}</p></div>
-            <div className={`${styles.card_content} ${styles._36}`}><p>{props.dataArray[35]}</p></div>
-            <div className={`${styles.card_content} ${styles._37}`}><p>{props.dataArray[36]}</p></div>
-            <div className={`${styles.card_content} ${styles._38}`}><p>{props.dataArray[37]}</p></div>
-            <div className={`${styles.card_content} ${styles._39}`}><p>{props.dataArray[38]}</p></div>
-            <div className={`${styles.card_content} ${styles._40}`}><p>{props.dataArray[39]}</p></div>
-            <div className={`${styles.card_content} ${styles._41}`}><p>{props.dataArray[40]}</p></div>
-            <div className={`${styles.card_content} ${styles._42}`}><p>{props.dataArray[41]}</p></div>
-            <div className={`${styles.card_content} ${styles._43}`}><p>{props.dataArray[42]}</p></div>
-            <div className={`${styles.card_content} ${styles._44}`}><p>{props.dataArray[43]}</p></div>
-            <div className={`${styles.card_content} ${styles._45}`}><p>{props.dataArray[44]}</p></div>
-            <div className={`${styles.card_content} ${styles._46}`}><p>{props.dataArray[45]}</p></div>
-            <div className={`${styles.card_content} ${styles._47}`}><p>{props.dataArray[46]}</p></div>
-            <div className={`${styles.card_content} ${styles._48}`}><p>{props.dataArray[47]}</p></div>
-            <div className={`${styles.card_content} ${styles._49}`}><p>{props.dataArray[48]}</p></div>
-            <div className={`${styles.card_content} ${styles._50}`}><p>{props.dataArray[49]}</p></div>
-            <div className={`${styles.card_content} ${styles._51}`}><p>{props.dataArray[50]}</p></div>
-            <div className={`${styles.card_content} ${styles._52}`}><p>{props.dataArray[51]}</p></div>
-            <div className={`${styles.card_content} ${styles._53}`}><p>{props.dataArray[52]}</p></div>
-            <div className={`${styles.card_content} ${styles._54}`}><p>{props.dataArray[53]}</p></div>
-            <div className={`${styles.card_content} ${styles._55}`}><p>{props.dataArray[54]}</p></div>
-            <div className={`${styles.card_content} ${styles._56}`}><p>{props.dataArray[55]}</p></div>
+        <div className={styles.container}>
+          <p className={styles.frame_title}>抽選済み番号一覧</p>
+          <div className={styles.card_frame}>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[0]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[1]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[2]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[3]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[4]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[5]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[6]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[7]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[8]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[9]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[10]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[11]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[12]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[13]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[14]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[15]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[16]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[17]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[18]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[19]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[20]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[21]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[22]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[23]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[24]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[25]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[26]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[27]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[28]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[29]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[30]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[31]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[32]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[33]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[34]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[35]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[36]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[37]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[38]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[39]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[40]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[41]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[42]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[43]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[44]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[45]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[46]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[47]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[48]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[49]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[50]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[51]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[52]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[53]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[54]}</p></div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.card_content}><p>{props.dataArray[55]}</p></div>
+            </div>
           </div>
         </div>
-      </div>
-    </div>
+
   )
 }
 

--- a/view-user/src/components/common/BingoResult/index.ts
+++ b/view-user/src/components/common/BingoResult/index.ts
@@ -1,0 +1,2 @@
+// "BingoResult"ディレクトリ内のモジュール"BingoResult.tsx"をdefaultとして再エクスポートする．
+export {default} from "./BingoResult"

--- a/view-user/src/components/common/Header/Header.module.css
+++ b/view-user/src/components/common/Header/Header.module.css
@@ -7,7 +7,7 @@
 
 .title {
     color: #333;
-    font-size: 3.5rem;
+    font-size: clamp(12px, calc(100vw / 12 ) , 56px);
     font-style: normal;
     font-weight: 700;
     line-height: 1;

--- a/view-user/src/components/common/index.ts
+++ b/view-user/src/components/common/index.ts
@@ -2,3 +2,4 @@
 // "Header"ディレクトリ全体をインポートし、内部のモジュールにアクセスできるようにする。
 // デフォルトエクスポートを再エクスポートする目的は、モジュールを使うときのimport文をシンプルにするため。
 export {default as Header} from "./Header"
+export {default as BingoResult} from "./BingoResult"

--- a/view-user/src/pages/index.tsx
+++ b/view-user/src/pages/index.tsx
@@ -2,11 +2,13 @@ import Image from "next/image";
 import styles from "@/styles/Home.module.css";
 import Head from "next/head";
 import type { NextPage } from "next";
-import { Header } from "@/components/common";
-import { BingoResult } from "@/components/common";
+import { Header, BingoResult } from "@/components/common";
 
 const Page: NextPage = () => {
-  const bingoResultNumber: number[] = [21, 5, 33, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4 ,55 ,66 ,32];
+  const bingoResultNumber: number[] = [
+    21, 5, 33, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 55,
+    66, 32,
+  ];
   return (
     <div className={styles.container}>
       <div>

--- a/view-user/src/pages/index.tsx
+++ b/view-user/src/pages/index.tsx
@@ -3,12 +3,18 @@ import styles from "@/styles/Home.module.css";
 import Head from "next/head";
 import type { NextPage } from "next";
 import { Header } from "@/components/common";
+import { BingoResult } from "@/components/common";
 
 const Page: NextPage = () => {
+  const dataArray:number[] = [21, 5, 33333]
   return (
   <div className={styles.container}>
     <div>
       <Header user="USER" />
+    </div>
+    <div>
+      {/* 数字は適当 */}
+      <BingoResult dataArray={dataArray}/>
     </div>
   </div>
   )

--- a/view-user/src/pages/index.tsx
+++ b/view-user/src/pages/index.tsx
@@ -6,18 +6,16 @@ import { Header } from "@/components/common";
 import { BingoResult } from "@/components/common";
 
 const Page: NextPage = () => {
-  const dataArray:number[] = [21, 5, 33333]
+  const bingoResultNumber: number[] = [21, 5, 33, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4 ,55 ,66 ,32];
   return (
-  <div className={styles.container}>
-    <div>
-      <Header user="USER" />
-    </div>
-    <div>
+    <div className={styles.container}>
+      <div>
+        <Header user="USER" />
+      </div>
       {/* 数字は適当 */}
-      <BingoResult dataArray={dataArray}/>
+      <BingoResult bingoResultNumber={bingoResultNumber} />
     </div>
-  </div>
-  )
+  );
 };
 
 export default Page;

--- a/view-user/src/styles/Home.module.css
+++ b/view-user/src/styles/Home.module.css
@@ -1,5 +1,5 @@
 .container {
-    height: 100vh;
+    height: 100%;
     width: 100vw;
   }
 

--- a/view-user/src/styles/Home.module.css
+++ b/view-user/src/styles/Home.module.css
@@ -1,6 +1,5 @@
 .container {
     height: 100vh;
     width: 100vw;
-    background-color: #C9AAAA;
   }
 

--- a/view-user/src/styles/globals.css
+++ b/view-user/src/styles/globals.css
@@ -1,3 +1,10 @@
 body {
   font-family: 'Noto Sans JP', sans-serif;
+  background-color: #C9AAAA;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+body::-webkit-scrollbar {
+  display:none;
 }


### PR DESCRIPTION
# 概要(このissueでやったことを簡単に)
resolve #22 

# スクリーンショット等あれば
![image](https://github.com/NUTFes/nutfes-Bingo/assets/95607264/e9ce7b73-d699-4753-8bfb-9b9804b3f1eb)
![image](https://github.com/NUTFes/nutfes-Bingo/assets/95607264/54434566-d8fc-4fb5-afd4-4e6e4995191e)


# テスト項目(テストしてほしいことを細かく書いてね)
- [ ] ヘッダーの下に番号一覧が表示されているか

# 備考

- **拡大・縮小すると，カードの大きさが変わる，横方向にはみ出す**
- 数字を入れるカードの大きさはpxで指定している
- 下スクロールすると背景が途中までしかできてない