### PR TITLE
Feature/issue48/api view user

### DIFF
--- a/view-user/src/components/common/BingoResult/BingoResult.tsx
+++ b/view-user/src/components/common/BingoResult/BingoResult.tsx
@@ -2,12 +2,16 @@ import React from "react";
 import { ReactNode } from "react";
 import styles from "./BingoResult.module.css";
 import { BingoIcon } from "@/components/common";
+import { BingoNumber } from "@/utils/api_methods";
 
 interface BingoResultProps {
-  bingoResultNumber: number[];
+  bingoResultNumber: BingoNumber[];
 }
 
 export const BingoResult = (props: BingoResultProps) => {
+  const copiedArray = [...props.bingoResultNumber];
+  const firstBingoNumber = copiedArray.pop();
+
   return (
     <div className={styles.content_wrapper}>
       <div className={styles.container}>
@@ -17,12 +21,14 @@ export const BingoResult = (props: BingoResultProps) => {
         </div>
         <div className={styles.card_frame}>
           <div className={styles.large_card}>
-            <div className={styles.card_content}>{props.bingoResultNumber[0]}</div>
+            <div className={styles.card_content}>
+              {firstBingoNumber?.data}
+            </div>
           </div>
           <div className={styles.small_card_frame}>
-            {props.bingoResultNumber.slice(1).map((num, index) => (
+            {props.bingoResultNumber.slice(0, -1).reverse().map((num, index) => (
               <div className={styles.small_card} key={index}>
-                <div className={styles.card_content}>{num}</div>
+                <div className={styles.card_content}>{num.data}</div>
               </div>
             ))}
           </div>

--- a/view-user/src/pages/index.tsx
+++ b/view-user/src/pages/index.tsx
@@ -1,15 +1,28 @@
-import { useState } from "react";
+import React, { useEffect, useState } from "react";
+import { getBingoNumber, BingoNumber } from "@/utils/api_methods";
 import type { NextPage } from "next";
 import styles from "@/styles/Home.module.css";
-import { Header, Modal ,BingoResult } from "@/components/common";
+import { Header, Modal, BingoResult } from "@/components/common";
 
 const Page: NextPage = () => {
   const [isOpened, setIsOpened] = useState(false);
   const isopenBool = () => setIsOpened(!isOpened);
-  const bingoResultNumber: number[] = [
-    21, 5, 33, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 55,
-    66, 32,
-  ];
+  const [bingoNumbers, setBingoNumbers] = useState<BingoNumber[]>([]);
+
+  useEffect(() => {
+    async function fetchBingoNumbers() {
+      try {
+        const response: BingoNumber[] = await getBingoNumber();
+        if (response) {
+          setBingoNumbers(response);
+        }
+      } catch (error) {
+        console.error("データの取得中にエラーが発生しました:", error);
+      }
+    }
+
+    fetchBingoNumbers();
+  }, [bingoNumbers]);
 
   return (
     <div className={styles.container}>
@@ -24,9 +37,9 @@ const Page: NextPage = () => {
           </button>
         </div>
       </Header>
-      <BingoResult bingoResultNumber={bingoResultNumber} />
+      <BingoResult bingoResultNumber={bingoNumbers} />
     </div>
-  )
-  };
+  );
+};
 
 export default Page;


### PR DESCRIPTION
# 概要(このissueでやったことを簡単に)
resolve #48
hasuraに保存されている値を表示させるようにした。
最新の値から表示するために配列の最後から順に値を表示させている。
# スクリーンショット等あれば
<img width="213" alt="image" src="https://github.com/NUTFes/nutfes-Bingo/assets/106811268/949abd47-de2f-4577-9017-cb4f594b3e1c">

# テスト項目(テストしてほしいことを細かく書いてね)
- `docker compose up view-user api -d`でコンテナを立ち上げて、[view-user](http://localhost:3000)にアクセスして値が表示されているか
- /testで番号をpostした後に見ると、そのpostした値が、大きいカードの中に表示され、下の方にはそれ以降の配列の中身が表示されているか。不安だったら、[hasura](http://localhost:8080/console)にアクセスして値を確認してください
# 備考
これを流用すればadmin側も終わるので終わりが見えてきたね！
chatgptありがとう！

