### PR TITLE
管理者ページのビンゴリストをDBから取得する&WebSocket通信

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       - "3001:3000"
     stdin_open: true
     tty: true
-    environment:
+    env_file:
       - .env
 
 volumes:

--- a/view-admin/next.config.js
+++ b/view-admin/next.config.js
@@ -4,3 +4,10 @@ const nextConfig = {
 }
 
 module.exports = nextConfig
+
+module.exports = {
+  env: {
+    API_URI: process.env.API_URI,
+    WS_API_URL: process.env.WS_API_URL,
+  }
+}

--- a/view-admin/package-lock.json
+++ b/view-admin/package-lock.json
@@ -16,6 +16,7 @@
         "eslint": "8.43.0",
         "eslint-config-next": "13.4.6",
         "graphql": "^16.7.1",
+        "graphql-ws": "^5.14.0",
         "next": "13.4.6",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -1891,6 +1892,17 @@
       },
       "peerDependencies": {
         "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/graphql-ws": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.14.0.tgz",
+      "integrity": "sha512-itrUTQZP/TgswR4GSSYuwWUzrE/w5GhbwM2GX3ic2U7aw33jgEsayfIlvaj7/GcIvZgNMzsPTrE5hqPuFUiE5g==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
       }
     },
     "node_modules/has": {

--- a/view-admin/package.json
+++ b/view-admin/package.json
@@ -18,6 +18,7 @@
     "eslint": "8.43.0",
     "eslint-config-next": "13.4.6",
     "graphql": "^16.7.1",
+    "graphql-ws": "^5.14.0",
     "next": "13.4.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/view-admin/src/components/common/BingoResult/BingoResult.tsx
+++ b/view-admin/src/components/common/BingoResult/BingoResult.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { ReactNode } from "react";
 import styles from "./BingoResult.module.css";
+import { BingoNumber } from "@/utils/api_methods";
 
 interface BingoResultProps {
-  bingoResultNumber: number[];
+  bingoResultNumber: BingoNumber[];
 }
 
 export const BingoResult = (props: BingoResultProps) => {
@@ -12,10 +13,11 @@ export const BingoResult = (props: BingoResultProps) => {
       <div className={styles.container}>
         <div className={styles.frame_title}>抽選済み番号一覧</div>
         <div className={styles.card_frame}>
-            {props.bingoResultNumber.map((num, index) => 
-              <div className={styles.card} key={index}>
-                <div className={styles.card_content}> {num}</div>
-              </div>)}
+            {props.bingoResultNumber.reverse().map((num, index) => (
+            <div className={styles.card} key={index}>
+              <div className={styles.card_content}> {num.data}</div>
+            </div>
+            ))}
           </div>
         </div>
       </div>

--- a/view-admin/src/components/common/BingoResult/BingoResult.tsx
+++ b/view-admin/src/components/common/BingoResult/BingoResult.tsx
@@ -13,7 +13,7 @@ export const BingoResult = (props: BingoResultProps) => {
       <div className={styles.container}>
         <div className={styles.frame_title}>抽選済み番号一覧</div>
         <div className={styles.card_frame}>
-            {props.bingoResultNumber.reverse().map((num, index) => (
+            {[...props.bingoResultNumber].reverse().map((num, index) => (
             <div className={styles.card} key={index}>
               <div className={styles.card_content}> {num.data}</div>
             </div>

--- a/view-admin/src/pages/index.tsx
+++ b/view-admin/src/pages/index.tsx
@@ -129,7 +129,7 @@ const Page: NextPage = () => {
               <option value="" hidden>
                 選択してください
               </option>
-              {bingoNumbers.map((number, index) => (
+              {[...bingoNumbers].reverse().map((number, index) => (
                 <option key={index} value={number.data}>
                   {number.data}
                 </option>

--- a/view-admin/src/pages/index.tsx
+++ b/view-admin/src/pages/index.tsx
@@ -2,27 +2,66 @@ import styles from "@/styles/Home.module.css";
 import type { NextPage } from "next";
 import { Header, BingoResult, Button } from "@/components/common";
 import { CgLogOut } from "react-icons/cg";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { BingoNumber, createBingoNumber, deleteBingoNumber, subscriptionBingoNumber } from "@/utils/api_methods";
 
 const Page: NextPage = () => {
-  const bingoResultNumber: number[] = [
-    21, 5, 33, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 55,
-    66, 32,
-  ];
-  const [data, setData] = useState("");
+  const [bingoNumbers, setBingoNumbers] = useState<BingoNumber[]>([]);
+  const [data, setData] = useState<number | null >(null);
   const [inputNumber, setInputNumber] = useState<number | null>(null);
   const [selectedNumber, setSelectedNumber] = useState<number | null>(null);
+
+  useEffect(() => {
+    async function fetchBingoNumbers() {
+      try {
+        const response: BingoNumber[] = await subscriptionBingoNumber();
+        if (response) {
+          setBingoNumbers(response);
+        }
+      } catch (error) {
+        console.error("データの取得中にエラーが発生しました:", error);
+      }
+    }
+
+    fetchBingoNumbers();
+  }, [bingoNumbers]);
 
   const handleSelectChange = (event: React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLSelectElement>) => {
     const newValue = parseInt(event.target.value);
     setSelectedNumber(isNaN(newValue) ? null : newValue);
   };
 
-  const handleSubmit = () => {
+  async function createMethod(data: number | null) {
+    if (data !== null) {
+      const newBingoNumber = await createBingoNumber(data);
+      if (newBingoNumber) {
+        console.log('Bingo number created:', newBingoNumber);
+      } else {
+        console.error('Failed to create bingo number.');
+      }
+    } else {
+      console.log('data is null');
+    }
+  }
+
+  async function deleteMethod(data: number) {
+    const BingoNumber = await deleteBingoNumber(data);
+    if (BingoNumber) {
+      console.log('Bingo number deleted:', BingoNumber);
+    } else {
+      console.error('Failed to delete bingo number.',Error);
+    }
+  }
+
+  const handleSubmit = async () => {
     if (inputNumber !== null) {
       console.log(inputNumber);
+      // await deleteBingoNumber(inputNumber);
+      deleteMethod(inputNumber);
     } else if (selectedNumber !== null) {
       console.log(selectedNumber);
+      // await deleteBingoNumber(selectedNumber);
+      deleteMethod(selectedNumber);
     }
     setInputNumber(null);
     setSelectedNumber(null);
@@ -48,16 +87,17 @@ const Page: NextPage = () => {
               max="99"
               name="data"
               placeholder="番号を入力"
-              value={data}
-              onChange={(event) => setData(event.target.value)}
+              value={data !== null ? data : ""}
+              onChange={(event) => setData(event.target.valueAsNumber)}
               className={styles.inputForm}
             />
             <button
               type="button"
               className={styles.Button}
-              onClick={() => {
+              onClick={async () => {
                 console.log(data);
-                setData("");
+                await createMethod(data);
+                setData(null);
               }}
             >
               送信
@@ -91,9 +131,9 @@ const Page: NextPage = () => {
               <option value="" hidden>
                 選択してください
               </option>
-              {bingoResultNumber.map((number, index) => (
-                <option key={index} value={number}>
-                  {number}
+              {bingoNumbers.map((number, index) => (
+                <option key={index} value={number.data}>
+                  {number.data}
                 </option>
               ))}
             </select>
@@ -108,7 +148,7 @@ const Page: NextPage = () => {
           </form>
         </div>
       </div>
-      <BingoResult bingoResultNumber={bingoResultNumber} />
+      <BingoResult bingoResultNumber={bingoNumbers} />
     </div>
   );
 };

--- a/view-admin/src/pages/index.tsx
+++ b/view-admin/src/pages/index.tsx
@@ -56,11 +56,9 @@ const Page: NextPage = () => {
   const handleSubmit = async () => {
     if (inputNumber !== null) {
       console.log(inputNumber);
-      // await deleteBingoNumber(inputNumber);
       deleteMethod(inputNumber);
     } else if (selectedNumber !== null) {
       console.log(selectedNumber);
-      // await deleteBingoNumber(selectedNumber);
       deleteMethod(selectedNumber);
     }
     setInputNumber(null);

--- a/view-admin/src/utils/api_methods.ts
+++ b/view-admin/src/utils/api_methods.ts
@@ -5,8 +5,7 @@ import { createClient } from "graphql-ws";
 import { userAgent } from "next/server";
 
 const wsLink = new GraphQLWsLink(createClient({
-  // url: process.env.WS_API_URL + "/v1/graphql",
-  url: "ws://localhost:8080/v1/graphql",
+  url: process.env.WS_API_URL + "/v1/graphql",
     // 認証関連はここに書く
 }));
 


### PR DESCRIPTION
# 概要(このissueでやったこと)
resolve #52 

# スクリーンショット等あれば
![image](https://github.com/NUTFes/nutfes-Bingo/assets/95607264/8243ebc1-95ce-486c-9592-e15c7a712ea4)

# テスト項目(テストするために必要な作業やテストしてほしいことを細かく記述)
- [x] 管理者ページで，番号の追加・削除ができる
　- 値が何も入ってないときは追加されないことを確認する
- [x] リロードせずに，番号一覧が更新される

# 備考
- 管理者ページで，追加または削除する番号を入力するときに，番号一覧のカードが入れ替わる ()
```typescript
export const BingoResult = (props: BingoResultProps) => {
  return (
    <div className={styles.content_wrapper}>
      <div className={styles.container}>
        <div className={styles.frame_title}>抽選済み番号一覧</div>
        <div className={styles.card_frame}>
            {props.bingoResultNumber.reverse().map((num, index) => (
            <div className={styles.card} key={index}>
              <div className={styles.card_content}> {num.data}</div>
            </div>
            ))}
          </div>
        </div>
      </div>
  );
};
```
この `reverse()` をなくせば，カードが入れ替わりは起きなかった．

- ~~番号の入力欄で，`e` が入力できてしまう~~

以上2点です．
