### PR TITLE
userページの番号一覧をリアルタイム更新

### DIFF
--- a/view-user/src/components/common/BingoResult/BingoResult.tsx
+++ b/view-user/src/components/common/BingoResult/BingoResult.tsx
@@ -26,7 +26,7 @@ export const BingoResult = (props: BingoResultProps) => {
             </div>
           </div>
           <div className={styles.small_card_frame}>
-            {props.bingoResultNumber.slice(0, -1).reverse().map((num, index) => (
+            {[...props.bingoResultNumber].slice(0, -1).reverse().map((num, index) => (
               <div className={styles.small_card} key={index}>
                 <div className={styles.card_content}>{num.data}</div>
               </div>

--- a/view-user/src/pages/index.tsx
+++ b/view-user/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { getBingoNumber, BingoNumber } from "@/utils/api_methods";
+import { getBingoNumber, BingoNumber, subscriptionBingoNumber } from "@/utils/api_methods";
 import type { NextPage } from "next";
 import styles from "@/styles/Home.module.css";
 import { Header, Modal, BingoResult } from "@/components/common";
@@ -12,7 +12,7 @@ const Page: NextPage = () => {
   useEffect(() => {
     async function fetchBingoNumbers() {
       try {
-        const response: BingoNumber[] = await getBingoNumber();
+        const response: BingoNumber[] = await subscriptionBingoNumber();
         if (response) {
           setBingoNumbers(response);
         }


### PR DESCRIPTION
# 概要(このissueでやったこと)
resolve #54 
userページのビンゴ番号一覧をWebSocketでリアルタイム更新できるように変更した．

# スクリーンショット等あれば
![image](https://github.com/NUTFes/nutfes-Bingo/assets/95607264/53fe45b6-1b12-41ee-b037-2071073cb077)

# テスト項目(テストするために必要な作業やテストしてほしいことを細かく記述)
- [ ] userページの番号一覧がadminページで番号の追加・削除したときにリアルタイムに反映されるか確認

# 備考
