### PR TITLE
Fix/issue65/delete keycloak

### DIFF
--- a/.docker/keycloak.Dockerfile
+++ b/.docker/keycloak.Dockerfile
@@ -1,9 +1,0 @@
-FROM quay.io/keycloak/keycloak:latest as builder
-ENV KC_DB=postgres
-RUN /opt/keycloak/bin/kc.sh build
-
-FROM openjdk:11-jdk-slim-bullseye as runner
-COPY --from=builder /opt/keycloak /opt/keycloak
-RUN apt update && apt install -y jq
-
-ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
-data/
-
 cloudflare/prod/*.pem
 cloudflare/prod/*.json
 
 *.env
 settings/
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,24 +32,6 @@ services:
       db:
         condition: service_healthy
 
-  keycloak:
-    build:
-      context: .docker
-      dockerfile: keycloak.Dockerfile
-    container_name: "bingo_keycloak"
-    ports:
-      - "8888:8080"
-    volumes:
-      - ./data/keycloak:/opt/keycloak/data # DB情報等が格納される
-    environment:
-      KEYCLOAK_ADMIN: admin # 管理ユーザーIDを設定
-      KEYCLOAK_ADMIN_PASSWORD: password # 管理ユーザーのパスワードを設定
-    depends_on:
-      - db
-      - api
-    command:
-      - start-dev
-
   view-user:
     build:
       context: .


### PR DESCRIPTION
# 概要(このissueでやったこと)
resolve #65
localhostのkeycloakはつかわれないので削除しました
# スクリーンショット等あれば

# テスト項目(テストするために必要な作業やテストしてほしいことを細かく記述)
- `docker compose up -d`でkeyclaokが立ち上がらないことを確認
- 他のコンテナに支障がないか3000,3001,8080にアクセスする。

# 備考
