### PR TITLE
[fix] フォントの縁取りCSSの変更

### DIFF
--- a/view-user/src/components/common/BingoResult/BingoResult.module.css
+++ b/view-user/src/components/common/BingoResult/BingoResult.module.css
@@ -63,7 +63,7 @@
   font-size: clamp(24px, calc(100vw / 9 ) , 68px);
   font-weight: bold;
   color: #FFF;
-  -webkit-text-stroke: 1px #07033E;
+  text-shadow: rgb(7, 3, 62) 2px 0px 0px, rgb(7, 3, 62) 1.75517px 0.958851px 0px, rgb(7, 3, 62) 1.0806px 1.68294px 0px, rgb(7, 3, 62) 0.141474px 1.99499px 0px, rgb(7, 3, 62) -0.832294px 1.81859px 0px, rgb(7, 3, 62) -1.60229px 1.19694px 0px, rgb(7, 3, 62) -1.97998px 0.28224px 0px, rgb(7, 3, 62) -1.87291px -0.701566px 0px, rgb(7, 3, 62) -1.30729px -1.5136px 0px, rgb(7, 3, 62) -0.421592px -1.95506px 0px, rgb(7, 3, 62) 0.567324px -1.91785px 0px, rgb(7, 3, 62) 1.41734px -1.41108px 0px, rgb(7, 3, 62) 1.92034px -0.558831px 0px;
 }
 
 @media (min-width: 820px) {
@@ -102,6 +102,6 @@
     font-size: clamp(24px, calc(100vw / 9 ) , 68px);
     font-weight: bold;
     color: #FFF;
-    -webkit-text-stroke: 1px #07033E;
+    text-shadow: rgb(7, 3, 62) 2px 0px 0px, rgb(7, 3, 62) 1.75517px 0.958851px 0px, rgb(7, 3, 62) 1.0806px 1.68294px 0px, rgb(7, 3, 62) 0.141474px 1.99499px 0px, rgb(7, 3, 62) -0.832294px 1.81859px 0px, rgb(7, 3, 62) -1.60229px 1.19694px 0px, rgb(7, 3, 62) -1.97998px 0.28224px 0px, rgb(7, 3, 62) -1.87291px -0.701566px 0px, rgb(7, 3, 62) -1.30729px -1.5136px 0px, rgb(7, 3, 62) -0.421592px -1.95506px 0px, rgb(7, 3, 62) 0.567324px -1.91785px 0px, rgb(7, 3, 62) 1.41734px -1.41108px 0px, rgb(7, 3, 62) 1.92034px -0.558831px 0px;
   }
 }

--- a/view-user/src/components/common/BingoResult/BingoResult.tsx
+++ b/view-user/src/components/common/BingoResult/BingoResult.tsx
@@ -20,17 +20,16 @@ export const BingoResult = (props: BingoResultProps) => {
           <p>BINGO Number List</p>
         </div>
         <div className={styles.card_frame}>
-          <div className={styles.large_card}>
-            <div className={styles.card_content}>
-              {firstBingoNumber?.data}
-            </div>
-          </div>
+          <div className={styles.large_card}>{firstBingoNumber?.data}</div>
           <div className={styles.small_card_frame}>
-            {[...props.bingoResultNumber].slice(0, -1).reverse().map((num, index) => (
-              <div className={styles.small_card} key={index}>
-                <div className={styles.card_content}>{num.data}</div>
-              </div>
-            ))}
+            {[...props.bingoResultNumber]
+              .slice(0, -1)
+              .reverse()
+              .map((num, index) => (
+                <div className={styles.small_card} key={index}>
+                  <div>{num.data}</div>
+                </div>
+              ))}
           </div>
         </div>
       </div>


### PR DESCRIPTION
# 概要(このissueでやったこと)
resolve #68 
ユーザーページの抽選済み番号の数字への縁取りが内側まで及んでいたことを修正。

# スクリーンショット等あれば
![FireShot Capture 035 - Bingo - localhost](https://github.com/NUTFes/nutfes-Bingo/assets/131145590/0f0b6cdc-87fc-42a1-89df-20b47adcbd2f)

# テスト項目(テストするために必要な作業やテストしてほしいことを細かく記述)

- [ ] 抽選済み番号の数字への縁取りが正しく描画される。

# 備考
（管理者ページと同じCSSでtext-stroke当ててもユーザーページだけおかしいのはなぜ？？）