### PR TITLE
[fix] 縁取りCSSを修正

### DIFF
--- a/view-user/src/components/common/BingoResult/BingoResult.module.css
+++ b/view-user/src/components/common/BingoResult/BingoResult.module.css
@@ -41,7 +41,15 @@
   font-size: clamp(1rem, 100vw / 3 , 10rem);
   font-weight: bold;
   color: #FFF;
-  -webkit-text-stroke: 4px #07033E;
+  text-shadow    :
+       3px  3px 1px #333333,
+      -3px  3px 1px #333333,
+       3px -3px 1px #333333,
+      -3px -3px 1px #333333,
+       3px  0px 1px #333333,
+       0px  3px 1px #333333,
+      -3px  0px 1px #333333,
+       0px -3px 1px #333333;
 }
 
 .small_card_frame {
@@ -80,7 +88,15 @@
     font-size: clamp(1rem, 100vw / 3 , 10rem);
     font-weight: bold;
     color: #FFF;
-    -webkit-text-stroke: 4px #07033E;
+    text-shadow    :
+    3px  3px 2px #333333,
+   -3px  3px 2px #333333,
+    3px -3px 2px #333333,
+   -3px -3px 2px #333333,
+    3px  0px 2px #333333,
+    0px  3px 2px #333333,
+   -3px  0px 2px #333333,
+    0px -3px 2px #333333;
   }
 
   .small_card_frame {


### PR DESCRIPTION
# 概要(このissueでやったこと)
resolve #87 
大きい方のカードの縁取りCSSを修正
# スクリーンショット等あれば
![FireShot Capture 052 - Bingo - localhost](https://github.com/NUTFes/nutfes-Bingo/assets/131145590/312f81af-a5a0-4675-9a49-d6481dec1e98)

# テスト項目(テストするために必要な作業やテストしてほしいことを細かく記述)

- [ ] 大きい方の抽選番号カードに表示される数字へ縁取りが正しく描画される。

# 備考
