### PR TITLE
[fix] オーバーレイの不具合を修正

### DIFF
--- a/view-admin/src/components/common/PrizeResult/PrizeResult.module.css
+++ b/view-admin/src/components/common/PrizeResult/PrizeResult.module.css
@@ -194,3 +194,77 @@
   display: flex;
   justify-content: center;
 }
+
+.visible {
+  color: #ffffff;
+  font-size: 20px;
+  margin: 100px auto;
+  width: 1em;
+  height: 1em;
+  border-radius: 50%;
+  position: relative;
+  text-indent: -9999em;
+  -webkit-animation: load 1.3s infinite linear;
+  animation: load 1.3s infinite linear;
+  -webkit-transform: translateZ(0);
+  -ms-transform: translateZ(0);
+  transform: translateZ(0);
+}
+@-webkit-keyframes load {
+  0%,
+  100% {
+    box-shadow: 0 -3em 0 0.2em, 2em -2em 0 0em, 3em 0 0 -1em, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 -1em, -3em 0 0 -1em, -2em -2em 0 0;
+  }
+  12.5% {
+    box-shadow: 0 -3em 0 0, 2em -2em 0 0.2em, 3em 0 0 0, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 -1em, -3em 0 0 -1em, -2em -2em 0 -1em;
+  }
+  25% {
+    box-shadow: 0 -3em 0 -0.5em, 2em -2em 0 0, 3em 0 0 0.2em, 2em 2em 0 0, 0 3em 0 -1em, -2em 2em 0 -1em, -3em 0 0 -1em, -2em -2em 0 -1em;
+  }
+  37.5% {
+    box-shadow: 0 -3em 0 -1em, 2em -2em 0 -1em, 3em 0em 0 0, 2em 2em 0 0.2em, 0 3em 0 0em, -2em 2em 0 -1em, -3em 0em 0 -1em, -2em -2em 0 -1em;
+  }
+  50% {
+    box-shadow: 0 -3em 0 -1em, 2em -2em 0 -1em, 3em 0 0 -1em, 2em 2em 0 0em, 0 3em 0 0.2em, -2em 2em 0 0, -3em 0em 0 -1em, -2em -2em 0 -1em;
+  }
+  62.5% {
+    box-shadow: 0 -3em 0 -1em, 2em -2em 0 -1em, 3em 0 0 -1em, 2em 2em 0 -1em, 0 3em 0 0, -2em 2em 0 0.2em, -3em 0 0 0, -2em -2em 0 -1em;
+  }
+  75% {
+    box-shadow: 0em -3em 0 -1em, 2em -2em 0 -1em, 3em 0em 0 -1em, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 0, -3em 0em 0 0.2em, -2em -2em 0 0;
+  }
+  87.5% {
+    box-shadow: 0em -3em 0 0, 2em -2em 0 -1em, 3em 0 0 -1em, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 0, -3em 0em 0 0, -2em -2em 0 0.2em;
+  }
+}
+@keyframes load {
+  0%,
+  100% {
+    box-shadow: 0 -3em 0 0.2em, 2em -2em 0 0em, 3em 0 0 -1em, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 -1em, -3em 0 0 -1em, -2em -2em 0 0;
+  }
+  12.5% {
+    box-shadow: 0 -3em 0 0, 2em -2em 0 0.2em, 3em 0 0 0, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 -1em, -3em 0 0 -1em, -2em -2em 0 -1em;
+  }
+  25% {
+    box-shadow: 0 -3em 0 -0.5em, 2em -2em 0 0, 3em 0 0 0.2em, 2em 2em 0 0, 0 3em 0 -1em, -2em 2em 0 -1em, -3em 0 0 -1em, -2em -2em 0 -1em;
+  }
+  37.5% {
+    box-shadow: 0 -3em 0 -1em, 2em -2em 0 -1em, 3em 0em 0 0, 2em 2em 0 0.2em, 0 3em 0 0em, -2em 2em 0 -1em, -3em 0em 0 -1em, -2em -2em 0 -1em;
+  }
+  50% {
+    box-shadow: 0 -3em 0 -1em, 2em -2em 0 -1em, 3em 0 0 -1em, 2em 2em 0 0em, 0 3em 0 0.2em, -2em 2em 0 0, -3em 0em 0 -1em, -2em -2em 0 -1em;
+  }
+  62.5% {
+    box-shadow: 0 -3em 0 -1em, 2em -2em 0 -1em, 3em 0 0 -1em, 2em 2em 0 -1em, 0 3em 0 0, -2em 2em 0 0.2em, -3em 0 0 0, -2em -2em 0 -1em;
+  }
+  75% {
+    box-shadow: 0em -3em 0 -1em, 2em -2em 0 -1em, 3em 0em 0 -1em, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 0, -3em 0em 0 0.2em, -2em -2em 0 0;
+  }
+  87.5% {
+    box-shadow: 0em -3em 0 0, 2em -2em 0 -1em, 3em 0 0 -1em, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 0, -3em 0em 0 0, -2em -2em 0 0.2em;
+  }
+}
+
+.hidden {
+  display: none;
+}

--- a/view-admin/src/components/common/PrizeResult/PrizeResult.module.css
+++ b/view-admin/src/components/common/PrizeResult/PrizeResult.module.css
@@ -165,3 +165,32 @@
 .toggle-button input {
   display: none;
 }
+
+.overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 3px;
+  background-color: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.overlay p {
+  text-align: center;
+  line-height: 1.8;
+  width: 100%;
+  height: 35%;
+  font-size: 4.8em;
+  font-weight: 700;
+  color: #d95b7f;
+  background-color: #07033e;
+}
+
+.toggle_container {
+  display: flex;
+  justify-content: center;
+}

--- a/view-admin/src/components/common/PrizeResult/PrizeResult.tsx
+++ b/view-admin/src/components/common/PrizeResult/PrizeResult.tsx
@@ -18,32 +18,49 @@ export const PrizeResult = (props: PrizeResultProps) => {
           {[...props.prizeResult]
             .sort((a, b) => a.id - b.id)
             .map((prizeResult) => (
-              <div className={prizeResult.existing? styles.card_overlay : styles.card} key={prizeResult.id}>
-                <div style={{position:"relative", width:"100%", height:"100%"}}>
+              <div className={styles.card} key={prizeResult.id}>
+                <div
+                  style={{
+                    position: "relative",
+                    width: "100%",
+                    height: "100%",
+                  }}
+                >
                   <Image
                     src={prizeResult.image}
+                    className={styles.image}
                     alt="PrizeImage"
                     fill
+                    style={{ objectFit: "cover" }}
                   />
-                  <p>{prizeResult.existing? "当選" : ""}</p>
                 </div>
-                <div style={{position:"relative"}} className={styles.card_content}>
+                <div
+                  style={{ position: "relative" }}
+                  className={styles.card_content}
+                >
                   {prizeResult.name}
-                  <div className={styles.toggle_button}>
-                  <input
-                    id="toggle"
-                    className={styles.toggle_input}
-                    type="checkbox"
-                    checked={prizeResult.existing}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                      console.log(prizeResult.id, e.target.checked);
-                      updatePrizeExisting(prizeResult.id, e.target.checked);
-                    }}
-                  />
-                  <label htmlFor="toggle" className={styles.toggle_label} />
                 </div>
-              </div>
-             </div>
+                {prizeResult.existing && (
+                  <div className={styles.overlay}>
+                    <p>当選！</p>
+                  </div>
+                )}
+                <div className={styles.toggle_container}>
+                  <div className={styles.toggle_button}>
+                    <input
+                      id="toggle"
+                      className={styles.toggle_input}
+                      type="checkbox"
+                      checked={prizeResult.existing}
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                        console.log(prizeResult.id, e.target.checked);
+                        updatePrizeExisting(prizeResult.id, e.target.checked);
+                      }}
+                    />
+                    <label htmlFor="toggle" className={styles.toggle_label} />
+                </div>
+                </div>
+            </div>
             ))}
         </div>
       </div>

--- a/view-admin/src/components/common/PrizeResult/PrizeResult.tsx
+++ b/view-admin/src/components/common/PrizeResult/PrizeResult.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ReactNode } from "react";
+import { ReactNode, useState } from "react";
 import styles from "./PrizeResult.module.css";
 import { BingoPrize, updatePrizeExisting } from "@/utils/api_methods";
 import Image from "next/image";
@@ -10,10 +10,15 @@ interface PrizeResultProps {
 }
 
 export const PrizeResult = (props: PrizeResultProps) => {
+  const [isVisible, setIsVisible] = useState(true);
+  const toggleVisibility = () => {
+    setIsVisible(!isVisible);
+  };
   return (
     <div className={styles.content_wrapper}>
       <div className={styles.container}>
         <div className={styles.frame_title}>景品一覧</div>
+        <div id="loading" className={isVisible ? styles.visible : styles.hidden}></div>
         <div className={styles.card_frame}>
           {[...props.prizeResult]
             .sort((a, b) => a.id - b.id)
@@ -32,6 +37,7 @@ export const PrizeResult = (props: PrizeResultProps) => {
                     alt="PrizeImage"
                     fill
                     style={{ objectFit: "cover" }}
+                    onLoad={toggleVisibility}
                   />
                 </div>
                 <div

--- a/view-user/src/components/common/PrizeResult/PrizeResult.module.css
+++ b/view-user/src/components/common/PrizeResult/PrizeResult.module.css
@@ -1,7 +1,7 @@
 .content_wrapper {
     padding: 2rem;
   }
-  
+
   .container {
     border-radius: 0.625rem;
     padding: 2rem;
@@ -10,7 +10,7 @@
     gap: 1.5rem;
     background-color: #ffffff80;
   }
-  
+
   @media (max-width: 820px) {
     .content_wrapper {
       padding: 0.5rem;
@@ -20,33 +20,35 @@
       gap: 0.5rem;
     }
   }
-  
+
   .frame_title {
-    /* font-size: clamp(下限, 可変, 上限)で動的に変わる */
-    font-size: clamp(12px, calc(100vw / 18), 24px);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0.5rem;
     font-weight: bold;
     color: #07033e;
-    padding-left: 10px;
+    padding: 0.3rem;
   }
-  
+
   .card_frame {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(min(30%, 300px), 2fr));
     gap: 10px;
   }
-  
+
   .card {
     aspect-ratio: 1 / 1;
     position: relative;
     border-radius: 3px;
-    border: 1px solid #333;
+    border: 1px solid #07033e;
     display: flex;
     flex-direction: column;
   }
-  
+
   .card_content {
-    font-size: clamp(2px, calc(100vw / 40), 18px);
-    color: #ffffff;
+    font-size: 0.9rem;
+    color: #07033e;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -57,11 +59,11 @@
       font-weight: normal;
     }
   }
-  
+
   .img {
     height: 100%;
   }
-  
+
   .card_overlay {
     aspect-ratio: 1 / 1;
     position: relative;
@@ -73,7 +75,7 @@
     align-items: center;
     justify-content: center;
   }
-  
+
   .card_overlay p {
     position: absolute;
     display: flex;
@@ -87,87 +89,28 @@
     top: clamp(10px, calc(100vw / 10), 100px);
 
   }
-  
-  .toggle_input {
+
+  .overlay {
     position: absolute;
-    left: 0;
     top: 0;
+    left: 0;
     width: 100%;
     height: 100%;
-    z-index: 5;
-    opacity: 0;
-    cursor: pointer;
+    border-radius: 3px;
+    background-color: rgba(0, 0, 0, 0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
-  
-  .toggle_label {
-    width: 85px;
-    height: 42px;
-    background: #fff;
-    border: 3px solid #eee;
-    position: relative;
-    display: inline-block;
-    border-radius: 40px;
-    transition: 0.4s;
-    box-sizing: border-box;
+
+  .overlay p {
+    text-align: center;
+    line-height: 1.63;
+    width: 100%;
+    height: 35%;
+    font-size: 1.6rem;
+    color: #d95b7f;
+    background-color: #07033e;
   }
-  
-  .toggle_label:after {
-    content: "";
-    position: absolute;
-    width: 32px;
-    height: 32px;
-    border-radius: 100%;
-    left: 2px;
-    top: 2px;
-    z-index: 2;
-    background: #eee;
-    transition: 0.4s;
-  }
-  
-  .toggle_input:checked + .toggle_label {
-    border: 3px solid #d95b7f;
-  }
-  
-  .toggle_input:checked + .toggle_label:after {
-    left: 42px;
-    background: #d95b7f;
-  }
-  
-  .toggle-button {
-    display: inline-block;
-    position: relative;
-    width: 100px;
-    height: 50px;
-    border-radius: 50px;
-    border: 3px solid #dddddd;
-    box-sizing: content-box;
-    cursor: pointer;
-    transition: border-color 0.4s;
-  }
-  
-  .toggle-button:has(:checked) {
-    border-color: #4bd865;
-  }
-  
-  .toggle-button::after {
-    position: absolute;
-    top: 50%;
-    left: 5px;
-    transform: translateY(-50%);
-    width: 45px;
-    height: 45px;
-    border-radius: 50%;
-    background-color: #dddddd;
-    content: "";
-    transition: left 0.4s;
-  }
-  
-  .toggle-button:has(:checked)::after {
-    left: 50px;
-    background-color: #4bd865;
-  }
-  
-  .toggle-button input {
-    display: none;
-  }
-  
+
+

--- a/view-user/src/components/common/PrizeResult/PrizeResult.module.css
+++ b/view-user/src/components/common/PrizeResult/PrizeResult.module.css
@@ -105,7 +105,7 @@
 
   .overlay p {
     text-align: center;
-    line-height: 1.63;
+    line-height: 1.8;
     width: 100%;
     height: 35%;
     font-size: 1.6rem;

--- a/view-user/src/components/common/PrizeResult/PrizeResult.module.css
+++ b/view-user/src/components/common/PrizeResult/PrizeResult.module.css
@@ -113,4 +113,76 @@
     background-color: #07033e;
   }
 
+  .visible {
+    color: #ffffff;
+    font-size: 20px;
+    margin: 100px auto;
+    width: 1em;
+    height: 1em;
+    border-radius: 50%;
+    position: relative;
+    text-indent: -9999em;
+    -webkit-animation: load 1.3s infinite linear;
+    animation: load 1.3s infinite linear;
+    -webkit-transform: translateZ(0);
+    -ms-transform: translateZ(0);
+    transform: translateZ(0);
+  }
+  @-webkit-keyframes load {
+    0%,
+    100% {
+      box-shadow: 0 -3em 0 0.2em, 2em -2em 0 0em, 3em 0 0 -1em, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 -1em, -3em 0 0 -1em, -2em -2em 0 0;
+    }
+    12.5% {
+      box-shadow: 0 -3em 0 0, 2em -2em 0 0.2em, 3em 0 0 0, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 -1em, -3em 0 0 -1em, -2em -2em 0 -1em;
+    }
+    25% {
+      box-shadow: 0 -3em 0 -0.5em, 2em -2em 0 0, 3em 0 0 0.2em, 2em 2em 0 0, 0 3em 0 -1em, -2em 2em 0 -1em, -3em 0 0 -1em, -2em -2em 0 -1em;
+    }
+    37.5% {
+      box-shadow: 0 -3em 0 -1em, 2em -2em 0 -1em, 3em 0em 0 0, 2em 2em 0 0.2em, 0 3em 0 0em, -2em 2em 0 -1em, -3em 0em 0 -1em, -2em -2em 0 -1em;
+    }
+    50% {
+      box-shadow: 0 -3em 0 -1em, 2em -2em 0 -1em, 3em 0 0 -1em, 2em 2em 0 0em, 0 3em 0 0.2em, -2em 2em 0 0, -3em 0em 0 -1em, -2em -2em 0 -1em;
+    }
+    62.5% {
+      box-shadow: 0 -3em 0 -1em, 2em -2em 0 -1em, 3em 0 0 -1em, 2em 2em 0 -1em, 0 3em 0 0, -2em 2em 0 0.2em, -3em 0 0 0, -2em -2em 0 -1em;
+    }
+    75% {
+      box-shadow: 0em -3em 0 -1em, 2em -2em 0 -1em, 3em 0em 0 -1em, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 0, -3em 0em 0 0.2em, -2em -2em 0 0;
+    }
+    87.5% {
+      box-shadow: 0em -3em 0 0, 2em -2em 0 -1em, 3em 0 0 -1em, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 0, -3em 0em 0 0, -2em -2em 0 0.2em;
+    }
+  }
+  @keyframes load {
+    0%,
+    100% {
+      box-shadow: 0 -3em 0 0.2em, 2em -2em 0 0em, 3em 0 0 -1em, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 -1em, -3em 0 0 -1em, -2em -2em 0 0;
+    }
+    12.5% {
+      box-shadow: 0 -3em 0 0, 2em -2em 0 0.2em, 3em 0 0 0, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 -1em, -3em 0 0 -1em, -2em -2em 0 -1em;
+    }
+    25% {
+      box-shadow: 0 -3em 0 -0.5em, 2em -2em 0 0, 3em 0 0 0.2em, 2em 2em 0 0, 0 3em 0 -1em, -2em 2em 0 -1em, -3em 0 0 -1em, -2em -2em 0 -1em;
+    }
+    37.5% {
+      box-shadow: 0 -3em 0 -1em, 2em -2em 0 -1em, 3em 0em 0 0, 2em 2em 0 0.2em, 0 3em 0 0em, -2em 2em 0 -1em, -3em 0em 0 -1em, -2em -2em 0 -1em;
+    }
+    50% {
+      box-shadow: 0 -3em 0 -1em, 2em -2em 0 -1em, 3em 0 0 -1em, 2em 2em 0 0em, 0 3em 0 0.2em, -2em 2em 0 0, -3em 0em 0 -1em, -2em -2em 0 -1em;
+    }
+    62.5% {
+      box-shadow: 0 -3em 0 -1em, 2em -2em 0 -1em, 3em 0 0 -1em, 2em 2em 0 -1em, 0 3em 0 0, -2em 2em 0 0.2em, -3em 0 0 0, -2em -2em 0 -1em;
+    }
+    75% {
+      box-shadow: 0em -3em 0 -1em, 2em -2em 0 -1em, 3em 0em 0 -1em, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 0, -3em 0em 0 0.2em, -2em -2em 0 0;
+    }
+    87.5% {
+      box-shadow: 0em -3em 0 0, 2em -2em 0 -1em, 3em 0 0 -1em, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 0, -3em 0em 0 0, -2em -2em 0 0.2em;
+    }
+  }
 
+  .hidden {
+    display: none;
+  }

--- a/view-user/src/components/common/PrizeResult/PrizeResult.tsx
+++ b/view-user/src/components/common/PrizeResult/PrizeResult.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ReactNode } from "react";
+import { ReactNode, useState } from "react";
 import styles from "./PrizeResult.module.css";
 import { BingoPrize, updatePrizeExisting } from "@/utils/api_methods";
 import Image from "next/image";
@@ -9,33 +9,43 @@ interface PrizeResultProps {
 }
 
 export const PrizeResult = (props: PrizeResultProps) => {
+  const [isVisible, setIsVisible] = useState(true);
+  const toggleVisibility = () => {
+    setIsVisible(!isVisible);
+  };
   return (
     <div className={styles.content_wrapper}>
       <div className={styles.container}>
         <div className={styles.frame_title}>
-          <Image
-            src="/GiftBox.svg"
-            alt="GiftBox"
-            width={19}
-            height={19}
-          />
+          <Image src="/GiftBox.svg" alt="GiftBox" width={19} height={19} />
           Prize List
         </div>
+        <div id="loading" className={isVisible ? styles.visible : styles.hidden}></div>
         <div className={styles.card_frame}>
           {[...props.prizeResult]
             .sort((a, b) => a.id - b.id)
             .map((prizeResult) => (
               <div className={styles.card} key={prizeResult.id}>
-                <div style={{position:"relative", width:"100%", height:"100%"}}>
+                <div
+                  style={{
+                    position: "relative",
+                    width: "100%",
+                    height: "100%",
+                  }}
+                >
                   <Image
                     src={prizeResult.image}
-                    className={styles.iamge}
+                    className={styles.image}
                     alt="PrizeImage"
                     fill
-                    style={{objectFit:"cover"}}
+                    style={{ objectFit: "cover" }}
+                    onLoad={toggleVisibility}
                   />
                 </div>
-                <div style={{position:"relative"}} className={styles.card_content}>
+                <div
+                  style={{ position: "relative" }}
+                  className={styles.card_content}
+                >
                   {prizeResult.name}
                 </div>
                 {prizeResult.existing && (

--- a/view-user/src/components/common/PrizeResult/PrizeResult.tsx
+++ b/view-user/src/components/common/PrizeResult/PrizeResult.tsx
@@ -12,24 +12,38 @@ export const PrizeResult = (props: PrizeResultProps) => {
   return (
     <div className={styles.content_wrapper}>
       <div className={styles.container}>
-        <div className={styles.frame_title}>景品一覧</div>
+        <div className={styles.frame_title}>
+          <Image
+            src="/GiftBox.svg"
+            alt="GiftBox"
+            width={19}
+            height={19}
+          />
+          Prize List
+        </div>
         <div className={styles.card_frame}>
           {[...props.prizeResult]
             .sort((a, b) => a.id - b.id)
             .map((prizeResult) => (
-              <div className={prizeResult.existing? styles.card_overlay : styles.card} key={prizeResult.id}>
+              <div className={styles.card} key={prizeResult.id}>
                 <div style={{position:"relative", width:"100%", height:"100%"}}>
                   <Image
                     src={prizeResult.image}
+                    className={styles.iamge}
                     alt="PrizeImage"
                     fill
+                    style={{objectFit:"cover"}}
                   />
-                  <p>{prizeResult.existing? "当選" : ""}</p>
                 </div>
                 <div style={{position:"relative"}} className={styles.card_content}>
                   {prizeResult.name}
+                </div>
+                {prizeResult.existing && (
+                  <div className={styles.overlay}>
+                    <p>当選！</p>
+                  </div>
+                )}
               </div>
-             </div>
             ))}
         </div>
       </div>


### PR DESCRIPTION
# 概要(このissueでやったこと)
resolve #103 
景品の画像にだけオーバーレイが適応されない不具合を修正
画像表示までの間にローディングアニメーションを追加
# スクリーンショット等あれば
![FireShot Capture 078 - Bingo - localhost](https://github.com/NUTFes/nutfes-Bingo/assets/131145590/2ccd8603-4ed9-47d9-9818-0402b6abad87)

![FireShot Capture 080 -  - localhost](https://github.com/NUTFes/nutfes-Bingo/assets/131145590/4bf838ed-e7db-412f-9fec-ab8a1e90d857)

https://github.com/NUTFes/nutfes-Bingo/assets/131145590/b9e340e8-453f-4342-8274-7f7b17281c70

# テスト項目(テストするために必要な作業やテストしてほしいことを細かく記述)

- [ ] 景品ページでオーバーレイが正しく描画される
- [ ] 画像表示までの間にローディングアニメーションが表示される


# 備考
