### PR TITLE
抽選順、昇順でビンゴ番号を表示できるようにした

### DIFF
--- a/view-user/src/components/common/BingoResult/BingoResult.module.css
+++ b/view-user/src/components/common/BingoResult/BingoResult.module.css
@@ -81,6 +81,20 @@
   text-shadow: rgb(7, 3, 62) 2px 0px 0px, rgb(7, 3, 62) 1.75517px 0.958851px 0px, rgb(7, 3, 62) 1.0806px 1.68294px 0px, rgb(7, 3, 62) 0.141474px 1.99499px 0px, rgb(7, 3, 62) -0.832294px 1.81859px 0px, rgb(7, 3, 62) -1.60229px 1.19694px 0px, rgb(7, 3, 62) -1.97998px 0.28224px 0px, rgb(7, 3, 62) -1.87291px -0.701566px 0px, rgb(7, 3, 62) -1.30729px -1.5136px 0px, rgb(7, 3, 62) -0.421592px -1.95506px 0px, rgb(7, 3, 62) 0.567324px -1.91785px 0px, rgb(7, 3, 62) 1.41734px -1.41108px 0px, rgb(7, 3, 62) 1.92034px -0.558831px 0px;
 }
 
+@media (max-width: 400px) {
+  .frame_title {
+    gap: 0.4rem;
+  }
+
+  .container {
+    gap: 1rem;
+  }
+
+  .content_wrapper {
+    padding: 1rem;
+  }
+}
+
 @media (min-width: 820px) {
   .large_card {
     display: flex;

--- a/view-user/src/components/common/BingoResult/BingoResult.module.css
+++ b/view-user/src/components/common/BingoResult/BingoResult.module.css
@@ -15,9 +15,16 @@
   display: flex;
   justify-content: center;
   gap: 0.5rem;
-  font-size: clamp(1rem, calc(100vw / 18 ) , 3rem);
+  font-size: clamp(1rem, calc(100vw / 20 ) , 3rem);
   font-weight: bold;
   color: #07033E;
+}
+
+.frame_title_button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
 }
 
 .card_frame {

--- a/view-user/src/components/common/BingoResult/BingoResult.tsx
+++ b/view-user/src/components/common/BingoResult/BingoResult.tsx
@@ -68,18 +68,11 @@ export const BingoResult = (props: BingoResultProps) => {
           <p>BINGO Number</p>
           <div className={styles.frame_title_button}>
             <Button
-              size="s"
+              size="xm"
               shape="square"
-              onClick={() => setResultChange(true)}
+              onClick={() => setResultChange(!resultChange)}
             >
-              抽選順
-            </Button>
-            <Button
-              size="s"
-              shape="square"
-              onClick={() => setResultChange(false)}
-            >
-              昇　順
+              {resultChange ? "番号順": "抽選順"}
             </Button>
           </div>
         </div>

--- a/view-user/src/components/common/BingoResult/BingoResult.tsx
+++ b/view-user/src/components/common/BingoResult/BingoResult.tsx
@@ -1,36 +1,90 @@
 import React from "react";
 import Image from "next/image";
 import styles from "./BingoResult.module.css";
-import { BingoIcon } from "@/components/common";
+import { BingoIcon, Button } from "@/components/common";
 import { BingoNumber } from "@/utils/api_methods";
+import { useState } from "react";
 
 interface BingoResultProps {
   bingoResultNumber: BingoNumber[];
 }
 
 export const BingoResult = (props: BingoResultProps) => {
+  const [resultChange, setResultChange] = useState<boolean>(true);
   const copiedArray = [...props.bingoResultNumber];
+  const sortCopiedArray = [...props.bingoResultNumber];
   const firstBingoNumber = copiedArray.pop();
+  const sortFirstBingoNumber = sortCopiedArray
+    .sort((a, b) => a.data - b.data)
+    .shift();
+
+  function ResultNumber() {
+    if (resultChange) {
+      return (
+        <>
+          <div className={styles.card_frame}>
+            <div className={styles.large_card}>{firstBingoNumber?.data}</div>
+            <div className={styles.small_card_frame}>
+              {[...props.bingoResultNumber]
+                .slice(0, -1)
+                .reverse()
+                .map((num, index) => (
+                  <div className={styles.small_card} key={index}>
+                    <div>{num.data}</div>
+                  </div>
+                ))}
+            </div>
+          </div>
+        </>
+      );
+    } else {
+      return (
+        <>
+          <div className={styles.card_frame}>
+            <div className={styles.large_card}>
+              {sortFirstBingoNumber?.data}
+            </div>
+            <div className={styles.small_card_frame}>
+              {[...props.bingoResultNumber]
+                .sort((a, b) => a.data - b.data)
+                .slice(1)
+                .map((num, index) => (
+                  <div className={styles.small_card} key={index}>
+                    <div>{num.data}</div>
+                  </div>
+                ))}
+            </div>
+          </div>
+        </>
+      );
+    }
+  }
 
   return (
     <div className={styles.content_wrapper}>
       <div className={styles.container}>
         <div className={styles.frame_title}>
-          <Image src="/BingoCard.svg" alt="BingoCard" width={25} height={25} />
+          <Image src="/BingoCard.svg" alt="BingoCard" width={20} height={20} />
           <p>BINGO Number</p>
+          <div className={styles.frame_title_button}>
+            <Button
+              size="s"
+              shape="square"
+              onClick={() => setResultChange(true)}
+            >
+              抽選順
+            </Button>
+            <Button
+              size="s"
+              shape="square"
+              onClick={() => setResultChange(false)}
+            >
+              昇　順
+            </Button>
+          </div>
         </div>
         <div className={styles.card_frame}>
-          <div className={styles.large_card}>{firstBingoNumber?.data}</div>
-          <div className={styles.small_card_frame}>
-            {[...props.bingoResultNumber]
-              .slice(0, -1)
-              .reverse()
-              .map((num, index) => (
-                <div className={styles.small_card} key={index}>
-                  <div>{num.data}</div>
-                </div>
-              ))}
-          </div>
+          <ResultNumber />
         </div>
       </div>
     </div>

--- a/view-user/src/components/common/Button/Button.module.css
+++ b/view-user/src/components/common/Button/Button.module.css
@@ -23,6 +23,7 @@
 
 .s {
   font-size: x-small;
+  padding:0.1rem;
 }
 
 
@@ -32,7 +33,7 @@
 
 
 .square {
-  border-radius: 0.5rem;
+  border-radius: 0.4rem;
 }
 
 .primary:hover {

--- a/view-user/src/components/common/Button/Button.module.css
+++ b/view-user/src/components/common/Button/Button.module.css
@@ -16,6 +16,11 @@
   padding: 0.8rem 1.5rem;
 }
 
+.xm {
+  font-size: x-small;
+  padding: 0.5rem 1.5rem;
+}
+
 .m {
   font-size: medium;
   padding: 0.4rem 1rem;

--- a/view-user/src/components/common/Button/Button.types.ts
+++ b/view-user/src/components/common/Button/Button.types.ts
@@ -1,5 +1,5 @@
 export interface props {
-    variants: "primary";
-    size: "l" | "m" | "s"
-    shape: "circle" | "square"
+  variants: "primary";
+  size: "l" | "m" | "xm" | "s";
+  shape: "circle" | "square";
 }


### PR DESCRIPTION
# 概要(このissueでやったこと)
resolve #108
抽選された順だけでは見づらいというご意見をもらったので昇順でも確認できるようにしました。
# スクリーンショット等あれば
<img width="214" alt="image" src="https://github.com/NUTFes/nutfes-Bingo/assets/106811268/ff575d57-e036-4f67-b207-2e6566b6291e">

# テスト項目(テストするために必要な作業やテストしてほしいことを細かく記述)
- 抽選順、昇順のボタンがあるか
- ボタンを押したら番号の順番が変わって表示されるか

# 備考
userにしか実装していないけどadminにも入りますか？