### PR TITLE
[mod] 正誤判定ボタンを押したときにテキストが出力されるように修正

### DIFF
--- a/view-admin/src/components/common/JudgementModal/JudgementModal.tsx
+++ b/view-admin/src/components/common/JudgementModal/JudgementModal.tsx
@@ -18,7 +18,8 @@ const Modal = ({
     100, 100, 100, 100, 100,
   ]);
   const [bingoNumbers, setBingoNumbers] = useState<BingoNumber[]>([]);
-  const [isIncluded, setIsIncluded] = useState(false);
+  const [isIncluded, setIsIncluded] = useState<boolean>(false);
+  const [isJudgementClicked, setIsJudgementClicked] = useState<boolean>(false);
 
   const handleInputChange = (
     index: number,
@@ -42,12 +43,18 @@ const Modal = ({
       inputElementArray[i].value = "";
     }
     setIsIncluded(false);
+    setIsJudgementClicked(false);
   };
 
   const checkInclusion = () => {
-    if (inputValues.every(number => bingoNumbers.map(num => num.data).includes(number))) {
+    if (
+      inputValues.every((number) =>
+        bingoNumbers.map((num) => num.data).includes(number)
+      )
+    ) {
       setIsIncluded(true);
     }
+    setIsJudgementClicked(true);
   };
 
   useEffect(() => {
@@ -63,6 +70,26 @@ const Modal = ({
     }
     fetchBingoNumbers();
   }, [bingoNumbers]);
+
+  function BingoJudgement() {
+    if (isIncluded) {
+      return (
+        <>
+          <div className={styles.jugementResults}>
+            <p>BINGO</p>
+          </div>
+        </>
+      );
+    } else {
+      return (
+        <>
+          <div className={styles.jugementResults}>
+            <p>NotYet!</p>
+          </div>
+        </>
+      );
+    }
+  }
 
   return (
     <>
@@ -120,15 +147,7 @@ const Modal = ({
                 >
                   リセット
                 </button>
-                {isIncluded ? (
-                  <div className={styles.jugementResults}>
-                    <p>BINGO</p>
-                  </div>
-                ) : (
-                  <div className={styles.jugementResults}>
-                    <p>NotYet!</p>
-                  </div>
-                )}
+                {isJudgementClicked && <BingoJudgement />}
               </div>
             </div>
           </div>

--- a/view-admin/src/components/common/JudgementModal/JudgementModal.tsx
+++ b/view-admin/src/components/common/JudgementModal/JudgementModal.tsx
@@ -71,25 +71,11 @@ const Modal = ({
     fetchBingoNumbers();
   }, [bingoNumbers]);
 
-  function BingoJudgement() {
-    if (isIncluded) {
-      return (
-        <>
-          <div className={styles.jugementResults}>
-            <p>BINGO</p>
-          </div>
-        </>
-      );
-    } else {
-      return (
-        <>
-          <div className={styles.jugementResults}>
-            <p>NotYet!</p>
-          </div>
-        </>
-      );
-    }
-  }
+  const BingoJudgement = () => (
+    <div className={styles.jugementResults}>
+      <p>{isIncluded ? "BINGO" : "NotYet!"}</p>
+    </div>
+  );
 
   return (
     <>


### PR DESCRIPTION
# 概要(このissueでやったこと)
resolve #110 
ビンゴの正誤判定ボタンを押されたときに結果を表示させるように変更しました。
# スクリーンショット等あれば
<img width="469" alt="image" src="https://github.com/NUTFes/nutfes-Bingo/assets/106811268/28da8048-e251-4576-aeda-b1727f158e14">

# テスト項目(テストするために必要な作業やテストしてほしいことを細かく記述)
- 正誤判定ボタンを押したら、結果に合ったテキストが表示されるか
- リセットボタンを押したらテキストも非表示になるか

# 備考
関数に置いて処理してるけど多分絶対クソコードなので修正できるならして欲しいです