### PR TITLE
Fix/issue104/resposive admin page header

### DIFF
--- a/view-admin/src/components/common/Button/Button.module.css
+++ b/view-admin/src/components/common/Button/Button.module.css
@@ -1,5 +1,5 @@
 .primary {
-  width: fit-content;
+  min-width: 8.324375rem;
   background-color: #d9d9d9;
   border: 1px solid #333333;
   color: #333333;

--- a/view-admin/src/components/common/Header/Header.module.css
+++ b/view-admin/src/components/common/Header/Header.module.css
@@ -9,13 +9,6 @@
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  overflow-x: scroll;
-  -ms-overflow-style: none; /* IE, Edge 対応 */
-  scrollbar-width: none;    /* Firefox 対応 */
-}
-
-.main::-webkit-scrollbar {
-  display: none; /* Chrome, Safari 対応 */
 }
 
 .title {

--- a/view-admin/src/components/common/Header/Header.module.css
+++ b/view-admin/src/components/common/Header/Header.module.css
@@ -6,6 +6,7 @@
 
 .main {
   display: flex;
+  flex-direction: row;
   align-items: center;
   justify-content: space-between;
   overflow-x: scroll;
@@ -19,7 +20,7 @@
 
 .title {
   color: #ffffff;
-  font-size: 5vw;
+  font-size: 6vw;
   font-style: normal;
   font-weight: 700;
   line-height: 0;
@@ -32,9 +33,21 @@
   padding: 0.9rem 0rem 0.5rem 1rem;
 }
 
-@media (min-width: 1225px) {
+@media (min-width: 1300px) {
   .title p {
     font-size: 3rem;
     margin: 1rem;
+  }
+}
+
+@media (max-width: 1300px) {
+  .main {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 1300px) and (min-width: 700px) {
+  .title {
+    font-size: 3vw;
   }
 }

--- a/view-admin/src/pages/index.tsx
+++ b/view-admin/src/pages/index.tsx
@@ -99,7 +99,7 @@ const Page: NextPage = () => {
         <JudgementModal isOpened={isOpened} setIsOpened={setIsOpened} />
         <Header user="Admin">
           <div className={styles.main}>
-            <Button size="l" shape="circle" onClick={() => ""}>
+            <Button size="m" shape="circle" onClick={() => ""}>
               <div className={styles.buttonContents}>
                 <Link className={styles.link} href="/testimage">
                   景品画像
@@ -203,7 +203,7 @@ const Page: NextPage = () => {
           Log in
         </Button>
       </div>
-    </div>  
+    </div>
   );
 };
 

--- a/view-admin/src/pages/index.tsx
+++ b/view-admin/src/pages/index.tsx
@@ -102,7 +102,7 @@ const Page: NextPage = () => {
             <Button size="m" shape="circle" onClick={() => ""}>
               <div className={styles.buttonContents}>
                 <Link className={styles.link} href="/testimage">
-                  景品画像
+                  景品追加
                 </Link>
               </div>
             </Button>

--- a/view-admin/src/pages/prizes/prizes.module.css
+++ b/view-admin/src/pages/prizes/prizes.module.css
@@ -8,7 +8,7 @@
 .main {
   display: flex;
   align-items: center;
-  margin-right: 1rem;
+  margin-bottom: 0.5rem;
 }
 
 .buttonContents {

--- a/view-admin/src/styles/Home.module.css
+++ b/view-admin/src/styles/Home.module.css
@@ -1,5 +1,5 @@
 .container {
-  height: 100%;
+  height: 100vh;
   background-color: aliceblue;
   background-image: linear-gradient(180deg, #d95b7f, #856db2, #07033e);
 }
@@ -64,6 +64,10 @@
   margin-bottom: 1rem;
 }
 
+.main {
+  margin-bottom: 0.5rem;
+}
+
 @media (min-width: 1225px) {
   .form {
     display: flex;
@@ -123,6 +127,14 @@
   .frame {
     text-align: center;
   }
+
+  .main {
+    display: grid;
+    place-items: center;
+    grid-template-columns: 1fr 1fr;
+    margin: 0;
+    margin-bottom: 0.5rem;
+  }
 }
 
 .frame select {
@@ -139,7 +151,7 @@
   color:black;
   border:1px red;
   font-size: small;
-  
+
 }
 
 .flexerror {


### PR DESCRIPTION
# 概要(このissueでやったこと)
resolve #104 
管理者ページのヘッダー部をレスポンシブ対応させました。
# スクリーンショット等あれば
スマホ表示 ↓
![FireShot Capture 083 -  - localhost](https://github.com/NUTFes/nutfes-Bingo/assets/131145590/463d1ed7-2611-4a40-9b61-48fe850012a9)

タブレット表示 ↓
![FireShot Capture 084 -  - localhost](https://github.com/NUTFes/nutfes-Bingo/assets/131145590/00268bbd-9833-4466-b349-7fb18e920616)


# テスト項目(テストするために必要な作業やテストしてほしいことを細かく記述)

- [ ] ヘッダー部が画面サイズを変更しても崩れない。レスポンシブに機能する。

# 備考
