### PR TITLE
[fix] 0が含まれる条件を考慮するように修正

### DIFF
--- a/view-admin/src/components/common/JudgementModal/JudgementModal.tsx
+++ b/view-admin/src/components/common/JudgementModal/JudgementModal.tsx
@@ -47,9 +47,9 @@ const Modal = ({
   };
 
   const checkInclusion = () => {
-    const remainingNumbers = inputValues.filter((number) => number !== 0);
+    const remainNumbers = inputValues.filter((number) => number !== 0);
     if (
-      remainingNumbers.every((number) =>
+      remainNumbers.every((number) =>
         bingoNumbers.map((num) => num.data).includes(number)
       )
     ) {

--- a/view-admin/src/components/common/JudgementModal/JudgementModal.tsx
+++ b/view-admin/src/components/common/JudgementModal/JudgementModal.tsx
@@ -47,8 +47,9 @@ const Modal = ({
   };
 
   const checkInclusion = () => {
+    const remainingNumbers = inputValues.filter((number) => number !== 0);
     if (
-      inputValues.every((number) =>
+      remainingNumbers.every((number) =>
         bingoNumbers.map((num) => num.data).includes(number)
       )
     ) {


### PR DESCRIPTION
# 概要(このissueでやったこと)
resolve #121 
正誤判定をする際にFREEマスを0で代替していたが、データベースに0が存在しないと判定が機能していなかった問題を修正しました。

# スクリーンショット等あれば
![FireShot Capture 086 -  - localhost](https://github.com/NUTFes/nutfes-Bingo/assets/131145590/c59b29be-71ac-40b9-8a27-93d34413618b)

# テスト項目(テストするために必要な作業やテストしてほしいことを細かく記述)

- [ ] インプット要素に0が含まれた状況でも正誤判定機能が正しく動作する。

# 備考
