### PR TITLE
Feature/issue101/recoil persist

### DIFF
--- a/view-admin/package-lock.json
+++ b/view-admin/package-lock.json
@@ -22,6 +22,7 @@
         "react-dom": "18.2.0",
         "react-hook-form": "^7.45.4",
         "react-icons": "^4.10.1",
+        "recoil-persist": "^5.1.0",
         "typescript": "5.1.3"
       }
     },
@@ -1938,6 +1939,12 @@
         "graphql": ">=0.11 <=16"
       }
     },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA==",
+      "peer": true
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -3123,6 +3130,34 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/recoil": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.7.tgz",
+      "integrity": "sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==",
+      "peer": true,
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/recoil-persist": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-5.1.0.tgz",
+      "integrity": "sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w==",
+      "peerDependencies": {
+        "recoil": "^0.7.2"
+      }
     },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
@@ -5243,6 +5278,12 @@
       "peer": true,
       "requires": {}
     },
+    "hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA==",
+      "peer": true
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -6014,6 +6055,21 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "recoil": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.7.tgz",
+      "integrity": "sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==",
+      "peer": true,
+      "requires": {
+        "hamt_plus": "1.0.2"
+      }
+    },
+    "recoil-persist": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-5.1.0.tgz",
+      "integrity": "sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w==",
+      "requires": {}
     },
     "regenerator-runtime": {
       "version": "0.13.11",

--- a/view-admin/package.json
+++ b/view-admin/package.json
@@ -24,6 +24,7 @@
     "react-dom": "18.2.0",
     "react-hook-form": "^7.45.4",
     "react-icons": "^4.10.1",
+    "recoil-persist": "^5.1.0",
     "typescript": "5.1.3"
   }
 }

--- a/view-admin/src/pages/_app.tsx
+++ b/view-admin/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import "@/styles/globals.css";
 import type { AppProps } from "next/app";
 import { SessionProvider } from "next-auth/react";
 import { useEffect } from "react";
+import { RecoilRoot } from "recoil";
 
 export default function App({
   Component,
@@ -16,7 +17,9 @@ export default function App({
 
   return (
     <SessionProvider session={session}>
-      <Component {...pageProps} />
+      <RecoilRoot>
+        <Component {...pageProps} />
+      </RecoilRoot>
     </SessionProvider>
   );
 }

--- a/view-admin/src/pages/atom.ts
+++ b/view-admin/src/pages/atom.ts
@@ -1,4 +1,4 @@
-import { BingoNumber } from "@/utils/api_methods";
+import { BingoNumber, BingoPrize } from "@/utils/api_methods";
 import { atom } from "recoil";
 import { recoilPersist } from "recoil-persist";
 
@@ -6,8 +6,15 @@ const { persistAtom } = recoilPersist({
   key: "recoil-persist",
   storage: typeof window === "undefined" ? undefined : window.localStorage,
 });
+
 export const bingoNumbersState = atom<BingoNumber[]>({
   key: "bingoNumbersState",
   default: [],
   effects_UNSTABLE: [persistAtom], // 永続化を有効
+});
+
+export const bingoPrizesState = atom<BingoPrize[]>({
+  key: "bingoPrizesState",
+  default: [],
+  effects_UNSTABLE: [persistAtom],
 });

--- a/view-admin/src/pages/atom.ts
+++ b/view-admin/src/pages/atom.ts
@@ -1,0 +1,13 @@
+import { BingoNumber } from "@/utils/api_methods";
+import { atom } from "recoil";
+import { recoilPersist } from "recoil-persist";
+
+const { persistAtom } = recoilPersist({
+  key: "recoil-persist",
+  storage: typeof window === "undefined" ? undefined : window.localStorage,
+});
+export const bingoNumbersState = atom<BingoNumber[]>({
+  key: "bingoNumbersState",
+  default: [],
+  effects_UNSTABLE: [persistAtom], // 永続化を有効
+});

--- a/view-admin/src/pages/index.tsx
+++ b/view-admin/src/pages/index.tsx
@@ -72,7 +72,7 @@ const Page: NextPage = () => {
       }
     }
     fetchBingoNumbers();
-  }, [bingoNumbers]);
+  }, [bingoNumbers, setBingoNumbers]);
 
   async function createMethod(data: number | null) {
     if (data != null) {

--- a/view-admin/src/pages/index.tsx
+++ b/view-admin/src/pages/index.tsx
@@ -18,8 +18,7 @@ import {
   deleteBingoNumber,
   subscriptionBingoNumber,
 } from "@/utils/api_methods";
-import { atom, useRecoilState } from "recoil";
-import { recoilPersist } from "recoil-persist";
+import { useRecoilState } from "recoil";
 import { bingoNumbersState } from "./atom";
 
 interface formData {

--- a/view-admin/src/pages/index.tsx
+++ b/view-admin/src/pages/index.tsx
@@ -18,6 +18,9 @@ import {
   deleteBingoNumber,
   subscriptionBingoNumber,
 } from "@/utils/api_methods";
+import { atom, useRecoilState } from "recoil";
+import { recoilPersist } from "recoil-persist";
+import { bingoNumbersState } from "./atom";
 
 interface formData {
   submitNumber: number | null;
@@ -28,9 +31,11 @@ interface formData {
 const Page: NextPage = () => {
   const { data: session } = useSession();
   const router = useRouter();
-  const [bingoNumbers, setBingoNumbers] = useState<BingoNumber[]>([]);
+  // const [bingoNumbers, setBingoNumbers] = useState<BingoNumber[]>([]);
   const [isOpened, setIsOpened] = useState<boolean>(false);
   const isopenBool = () => setIsOpened(!isOpened);
+  
+  const [bingoNumbers, setBingoNumbers] = useRecoilState(bingoNumbersState)
 
   const {
     register,

--- a/view-admin/src/pages/prizes/index.tsx
+++ b/view-admin/src/pages/prizes/index.tsx
@@ -29,7 +29,7 @@ const Page: NextPage = () => {
       }
     }
     getPrizesImage();
-  }, []);
+  }, []); // このuseEffectはページ読み込み時に1度だけ実行したい
 
   useEffect(() => {
     async function subscriptionBingoExisting() {

--- a/view-admin/src/pages/prizes/index.tsx
+++ b/view-admin/src/pages/prizes/index.tsx
@@ -9,10 +9,14 @@ import {
   subscriptionBingoPrize,
   getBingoPrize,
 } from "@/utils/api_methods";
+import { bingoPrizesState } from "../atom";
+import { useRecoilState } from "recoil";
 
 const Page: NextPage = () => {
   const router = useRouter();
-  const [bingoPrize, setBingoPrize] = useState<BingoPrize[]>([]); // getしてきた画像
+  // const [bingoPrize, setBingoPrize] = useState<BingoPrize[]>([]); // getしてきた画像
+
+  const [bingoPrize, setBingoPrize] = useRecoilState(bingoPrizesState);
 
   useEffect(() => {
     async function fetchBingoPrizes() {

--- a/view-admin/src/pages/prizes/index.tsx
+++ b/view-admin/src/pages/prizes/index.tsx
@@ -14,29 +14,43 @@ import { useRecoilState } from "recoil";
 
 const Page: NextPage = () => {
   const router = useRouter();
-  // const [bingoPrize, setBingoPrize] = useState<BingoPrize[]>([]); // getしてきた画像
-
   const [bingoPrize, setBingoPrize] = useRecoilState(bingoPrizesState);
 
   useEffect(() => {
-    async function fetchBingoPrizes() {
+    async function getPrizesImage() {
       try {
         const getData: BingoPrize[] = await getBingoPrize();
         if (getData) {
           setBingoPrize(getData);
+          console.log("getPrizeImageした");
         }
+      } catch (error) {
+        console.error("データの取得中にエラーが発生しました:", error);
+      }
+    }
+    getPrizesImage();
+  }, []);
 
+  useEffect(() => {
+    async function subscriptionBingoExisting() {
+      try {
+        // サブスクリプションを使用してデータを取得
         const subscriptionData: BingoPrize[] = await subscriptionBingoPrize();
-        setBingoPrize((BingoPrize) => {
-          return [...BingoPrize];
+
+        setBingoPrize((oldPrize) => {
+          // existing プロパティを subscriptionData の値で上書き
+          const updatedPrizes = oldPrize.map((prize) => {
+            const matchingSubscriptionPrize = subscriptionData.find((subscriptionPrize) => subscriptionPrize.id === prize.id);  // oldPrizeとsubscriptionDataのidが一致するものを探して上書きする
+            return matchingSubscriptionPrize ? { ...prize, existing: matchingSubscriptionPrize.existing } : prize;
+          });
+          return updatedPrizes;
         });
       } catch (error) {
         console.error("データの取得中にエラーが発生しました:", error);
       }
     }
-
-    fetchBingoPrizes();
-  }, [bingoPrize]);
+    subscriptionBingoExisting();
+  }, [bingoPrize, setBingoPrize]);
 
   // 景品の文字検索機能 divタグの要素を取得しています。
   const [searchText, setSearchText] = useState("");

--- a/view-admin/src/utils/api_methods.ts
+++ b/view-admin/src/utils/api_methods.ts
@@ -54,7 +54,7 @@ export async function subscriptionBingoNumber(): Promise<BingoNumber[]> {
   try {
     const response = await client.subscribe({
       query: gql`
-        subscription MySubscription {
+        subscription AdminNumberSubscription {
           bingo_number {
             data
             id
@@ -143,7 +143,7 @@ export async function subscriptionBingoPrize(): Promise<BingoPrize[]> {
   try {
     const response = await client.subscribe({
       query: gql`
-        subscription MySubscription {
+        subscription AdminExistingSubscription {
           bingo_prize {
             existing
             id

--- a/view-user/package-lock.json
+++ b/view-user/package-lock.json
@@ -20,6 +20,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-icons": "^4.10.1",
+        "recoil-persist": "^5.1.0",
         "typescript": "5.1.3"
       }
     },
@@ -1920,6 +1921,12 @@
         "graphql": ">=0.11 <=16"
       }
     },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA==",
+      "peer": true
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -3005,6 +3012,34 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/recoil": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.7.tgz",
+      "integrity": "sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==",
+      "peer": true,
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/recoil-persist": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-5.1.0.tgz",
+      "integrity": "sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w==",
+      "peerDependencies": {
+        "recoil": "^0.7.2"
+      }
     },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",

--- a/view-user/package.json
+++ b/view-user/package.json
@@ -22,6 +22,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-icons": "^4.10.1",
+    "recoil-persist": "^5.1.0",
     "typescript": "5.1.3"
   }
 }

--- a/view-user/src/pages/_app.tsx
+++ b/view-user/src/pages/_app.tsx
@@ -2,9 +2,14 @@ import '@/styles/reset.css'
 import '@/styles/globals.css'
 import type { AppProps } from 'next/app'
 import { Inter } from 'next/font/google'
+import { RecoilRoot } from 'recoil'
 
 const inter = Inter({ subsets: ['latin'] })
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return (
+    <RecoilRoot>
+      <Component {...pageProps} />
+    </RecoilRoot>
+  )
 }

--- a/view-user/src/pages/atom.ts
+++ b/view-user/src/pages/atom.ts
@@ -1,0 +1,20 @@
+import { BingoNumber, BingoPrize } from "@/utils/api_methods";
+import { atom } from "recoil";
+import { recoilPersist } from "recoil-persist";
+
+const { persistAtom } = recoilPersist({
+  key: "recoil-persist",
+  storage: typeof window === "undefined" ? undefined : window.localStorage,
+});
+
+export const bingoNumbersState = atom<BingoNumber[]>({
+  key: "bingoNumbersState",
+  default: [],
+  effects_UNSTABLE: [persistAtom], // 永続化を有効
+});
+
+export const bingoPrizesState = atom<BingoPrize[]>({
+  key: "bingoPrizesState",
+  default: [],
+  effects_UNSTABLE: [persistAtom],
+});

--- a/view-user/src/pages/index.tsx
+++ b/view-user/src/pages/index.tsx
@@ -27,7 +27,7 @@ const Page: NextPage = () => {
     }
 
     fetchBingoNumbers();
-  }, [bingoNumbers]);
+  }, [bingoNumbers, setBingoNumbers]);
 
   return (
     <div className={styles.container}>

--- a/view-user/src/pages/index.tsx
+++ b/view-user/src/pages/index.tsx
@@ -5,12 +5,14 @@ import Image from "next/image";
 import styles from "@/styles/Home.module.css";
 import { Header, Modal, BingoResult, Button } from "@/components/common";
 import { useRouter } from "next/router";
+import { bingoNumbersState } from "./atom";
+import { useRecoilState } from "recoil";
 
 const Page: NextPage = () => {
   const [isOpened, setIsOpened] = useState(false);
   const router = useRouter();
   const isopenBool = () => setIsOpened(!isOpened);
-  const [bingoNumbers, setBingoNumbers] = useState<BingoNumber[]>([]);
+  const [bingoNumbers, setBingoNumbers] = useRecoilState(bingoNumbersState);
 
   useEffect(() => {
     async function fetchBingoNumbers() {

--- a/view-user/src/pages/prizes/index.tsx
+++ b/view-user/src/pages/prizes/index.tsx
@@ -29,7 +29,7 @@ const Page: NextPage = () => {
       }
     }
     getPrizesImage();
-  }, []);
+  }, []); // このuseEffectはページ読み込み時に1度だけ実行したい
 
   useEffect(() => {
     async function subscriptionBingoExisting() {

--- a/view-user/src/utils/api_methods.ts
+++ b/view-user/src/utils/api_methods.ts
@@ -54,7 +54,7 @@ export async function subscriptionBingoNumber(): Promise<BingoNumber[]> {
   try {
     const response = await client.subscribe({
       query: gql`
-        subscription MySubscription {
+        subscription UserNumberSubscription {
           bingo_number {
             data
             id
@@ -143,7 +143,7 @@ export async function subscriptionBingoPrize(): Promise<BingoPrize[]> {
   try {
     const response = await client.subscribe({
       query: gql`
-        subscription MySubscription {
+        subscription UserExistingSubscription {
           bingo_prize {
             existing
             id


### PR DESCRIPTION
# 概要(このissueでやったこと)
- resolves #101 
- recoil-persistを使用して，localstorageに景品データ，番号データを保存
- admin/userページのuseEffectを2つに分割(get, subscription)

# スクリーンショット等あれば
![image](https://github.com/NUTFes/nutfes-Bingo/assets/95607264/343d7514-58d1-47a5-bfe4-f9d659a4244b)

# テスト項目(テストするために必要な作業やテストしてほしいことを細かく記述)
- user/adminの番号，景品をlocalStorageに保存
- 

# 備考
- userの番号一覧で，エラーが起きる(無視しても多分問題ない, スマホで見たときどうなるかわからないが．)
localStorageの値と取得してきた値が一致していないから？
![image](https://github.com/NUTFes/nutfes-Bingo/assets/95607264/bf2d5d57-5e0c-49fe-a664-5455715ccfe2)
- userの番号一覧だけlocalStorageを使わないほうがよさそう．(まだ変更していない)
