### PR TITLE
[fix] prizeのuseEffectをgetとsubscriptionに分けた

### DIFF
--- a/view-admin/src/pages/prizes/index.tsx
+++ b/view-admin/src/pages/prizes/index.tsx
@@ -15,23 +15,39 @@ const Page: NextPage = () => {
   const [bingoPrize, setBingoPrize] = useState<BingoPrize[]>([]); // getしてきた画像
 
   useEffect(() => {
-    async function fetchBingoPrizes() {
+    async function getPrizeImage() {
       try {
         const getData: BingoPrize[] = await getBingoPrize();
         if (getData) {
           setBingoPrize(getData);
+          console.log("getPrize");
         }
-
-        const subscriptionData: BingoPrize[] = await subscriptionBingoPrize();
-        setBingoPrize((BingoPrize) => {
-          return [...BingoPrize];
-        });
       } catch (error) {
         console.error("データの取得中にエラーが発生しました:", error);
       }
     }
+    getPrizeImage();
+  }, []);
 
-    fetchBingoPrizes();
+  useEffect(() => {
+    async function subscriptionBingoExisting() {
+      try {
+        const subscriptionData: BingoPrize[] = await subscriptionBingoPrize();
+        setBingoPrize((oldPrize) => {
+          // existing プロパティを subscriptionData で更新
+          const updatedPrizes = oldPrize.map((prize) => {
+            const matchingSubscriptionPrize = subscriptionData.find(
+              (subscriptionPrize) => subscriptionPrize.id === prize.id
+            ); // oldPrizeとsubscriptionDataのidが一致するものを探して上書き
+            return matchingSubscriptionPrize
+              ? { ...prize, existing: matchingSubscriptionPrize.existing }
+              : prize;
+          });
+          return updatedPrizes;
+        });
+      } catch (error) {}
+    }
+    subscriptionBingoExisting();
   }, [bingoPrize]);
 
   // 景品の文字検索機能 divタグの要素を取得しています。

--- a/view-user/src/pages/prizes/index.tsx
+++ b/view-user/src/pages/prizes/index.tsx
@@ -4,33 +4,50 @@ import Image from "next/image";
 import { Header, Button, PrizeResult } from "@/components/common";
 import { useRouter } from "next/router";
 import { useState, useEffect } from "react";
-import { BingoPrize,
+import {
+  BingoPrize,
   subscriptionBingoPrize,
   getBingoPrize,
- } from "@/utils/api_methods";
+} from "@/utils/api_methods";
 
 const Page: NextPage = () => {
   const router = useRouter();
   const [bingoPrize, setBingoPrize] = useState<BingoPrize[]>([]); // get
 
   useEffect(() => {
-    async function fetchBingoPrizes() {
+    async function getPrizeImage() {
       try {
         const getData: BingoPrize[] = await getBingoPrize();
         if (getData) {
           setBingoPrize(getData);
+          console.log("getPrize");
         }
-
-        const subscriptionData: BingoPrize[] = await subscriptionBingoPrize();
-        setBingoPrize((BingoPrize) => {
-          return [...BingoPrize];
-        })
       } catch (error) {
-        console.error("データの取得中にエラーが発生しました:", error);
+        console.log("データの取得中にえらーが発生しました:", error);
       }
     }
+    getPrizeImage();
+  }, []);
 
-    fetchBingoPrizes();
+  useEffect(() => {
+    async function subscriptionBingoExisting() {
+      try {
+        const subscriptionData: BingoPrize[] = await subscriptionBingoPrize();
+        setBingoPrize((oldPrize) => {
+          // existing プロパティを subscriptionData で更新
+          const updatedPrizes = oldPrize.map((prize) => {
+            const matchingSubscriptionPrize = subscriptionData.find(
+              (subscriptionPrize) => subscriptionPrize.id === prize.id
+            ); // oldPrizeとsubscriptionDataのidが一致するものを探して上書き
+            return matchingSubscriptionPrize
+              ? { ...prize, existing: matchingSubscriptionPrize.existing }
+              : prize;
+          });
+          return updatedPrizes;
+        });
+      } catch (error) {}
+    }
+    subscriptionBingoExisting();
   }, [bingoPrize]);
 
   return (


### PR DESCRIPTION
# 概要(このissueでやったこと)
resolve #140

# スクリーンショット等あれば
![image](https://github.com/NUTFes/nutfes-Bingo/assets/95607264/cf818104-7d48-4a69-8b2e-47fb9e9e57ad)

# テスト項目(テストするために必要な作業やテストしてほしいことを細かく記述)
- prizeページに遷移したときに，getが一度だけ実施される(admin/user共通)(consoleにログを表示している)
- adminで景品の当選のトグルを操作したときに，user側で操作した景品(同じidの景品)にオーバーレイがかかる
- userで，画像を追加したときに，ページリロードをしたら一覧が更新される

# 備考
