### PR TITLE
Feat/yama/154 add multilingual support

### DIFF
--- a/view-user/next.config.js
+++ b/view-user/next.config.js
@@ -11,4 +11,8 @@ module.exports = {
     WS_API_URL: process.env.WS_API_URL,
     X_HASURA_ADMIN_SECRET: process.env.HASURA_GRAPHQL_ADMIN_SECRET,
   },
+  i18n: {
+    locales: ["ja", "en"],
+    defaultLocale: "ja",
+  },
 };

--- a/view-user/src/components/common/BingoResult/BingoResult.tsx
+++ b/view-user/src/components/common/BingoResult/BingoResult.tsx
@@ -4,12 +4,17 @@ import styles from "./BingoResult.module.css";
 import { BingoIcon, Button } from "@/components/common";
 import { BingoNumber } from "@/utils/api_methods";
 import { useState } from "react";
+import { useRouter } from 'next/router'
+import { ja } from "@/pages/locales/ja";
+import { en } from "@/pages/locales/en";
 
 interface BingoResultProps {
   bingoResultNumber: BingoNumber[];
 }
 
 export const BingoResult = (props: BingoResultProps) => {
+  const { locale } = useRouter()
+  const t = locale === "ja" ? ja : en;
   const [resultChange, setResultChange] = useState<boolean>(true);
   const copiedArray = [...props.bingoResultNumber];
   const sortCopiedArray = [...props.bingoResultNumber];
@@ -65,14 +70,14 @@ export const BingoResult = (props: BingoResultProps) => {
       <div className={styles.container}>
         <div className={styles.frame_title}>
           <Image src="/BingoCard.svg" alt="BingoCard" width={20} height={20} />
-          <p>BINGO Number</p>
+          <p>{t.SUB_TITLE_NUMBER}</p>
           <div className={styles.frame_title_button}>
             <Button
               size="xm"
               shape="square"
               onClick={() => setResultChange(!resultChange)}
             >
-              {resultChange ? "番号順": "抽選順"}
+              {resultChange ? <p>{t.NUMBER_ORDER_BUTTON}</p> : <p>{t.LOTTERY_ORDER_BUTTON}</p>}
             </Button>
           </div>
         </div>

--- a/view-user/src/components/common/Modal/Modal.module.css
+++ b/view-user/src/components/common/Modal/Modal.module.css
@@ -38,8 +38,8 @@
 
 .btnClose {
   position: absolute;
-  top: 9px;
-  right: 10px;
+  top: 11px;
+  right: 11px;
   padding: 0;
   font-size: 1.4rem;
   line-height: 1;

--- a/view-user/src/components/common/Modal/Modal.module.css
+++ b/view-user/src/components/common/Modal/Modal.module.css
@@ -18,35 +18,12 @@
   object-fit: cover;
   padding: 40px;
   overflow: hidden;
-  background-color: #c67979;
-  box-shadow: 0 0 0 3.56rem #d9d9d9;
+  backdrop-filter: blur(1rem);
+  border: 1px solid rgba(255, 255, 255, 0.4);
   border-radius: 5px;
   animation: zoomIn 0.8s cubic-bezier(0.25, 1, 0.5, 1) 1 forwards;
   will-change: transform, opacity;
 }
-
-.number {
-    display: flex;
-    flex-flow: column;
-    justify-content: center;
-    align-items: center;
-    color: #d9d9d9;
-    font-size: clamp(2rem, 2vw, 3rem);
-    font-weight: 700;
-    font-feature-settings: "palt" 1;
-  }
-
-  .number p {
-    display: flex;
-    flex-flow: column;
-    justify-content: center;
-    align-items: center;
-    color: #d9d9d9;
-    font-size: clamp(0.5rem, 50vw,16rem);
-    font-weight: 700;
-    font-feature-settings: "palt" 1;
-    line-height: 1;
-  }
 
 @keyframes zoomIn {
   0% {
@@ -64,7 +41,7 @@
   top: 9px;
   right: 10px;
   padding: 0;
-  font-size: 2.7rem;
+  font-size: 1.4rem;
   line-height: 1;
   color: #d9d9d9;
   cursor: pointer;

--- a/view-user/src/components/common/Modal/Modal.module.css
+++ b/view-user/src/components/common/Modal/Modal.module.css
@@ -13,7 +13,7 @@
 
 .content {
   position: relative;
-  z-index: 1;
+  z-index: 50;
   box-sizing: border-box;
   object-fit: cover;
   padding: 40px;
@@ -51,6 +51,7 @@
 
 .background {
   position: absolute;
+  z-index: 25;
   top: 0;
   left: 0;
   width: 100%;

--- a/view-user/src/components/common/Modal/Modal.tsx
+++ b/view-user/src/components/common/Modal/Modal.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from "react";
 import styles from "./Modal.module.css";
-import { RxCrossCircled } from "react-icons/rx"
+import { RxCross1 } from "react-icons/rx"
 
 interface ModalProps {
   children: ReactNode;
@@ -26,9 +26,9 @@ const Modal = ({
         <div className={styles.wrapper}>
           <div className={styles.content}>
             <button className={styles.btnClose} onClick={closeModal}>
-              <RxCrossCircled />
+              <RxCross1 />
             </button>
-            <p className={styles.number}>{children}</p>
+            {children}
           </div>
           {canCloseByClickingBackground && (
             <div className={styles.background} onClick={closeModal} />

--- a/view-user/src/components/common/PrizeResult/PrizeResult.tsx
+++ b/view-user/src/components/common/PrizeResult/PrizeResult.tsx
@@ -3,12 +3,17 @@ import { ReactNode, useState } from "react";
 import styles from "./PrizeResult.module.css";
 import { BingoPrize, updatePrizeExisting } from "@/utils/api_methods";
 import Image from "next/image";
+import { useRouter } from 'next/router'
+import { ja } from "@/pages/locales/ja";
+import { en } from "@/pages/locales/en";
 
 interface PrizeResultProps {
   prizeResult: BingoPrize[];
 }
 
 export const PrizeResult = (props: PrizeResultProps) => {
+  const { locale } = useRouter()
+  const t = locale === "ja" ? ja : en;
   const [isImageVisible, setIsImageVisible] = useState(true);
   const imageVisibility = () => {
     setIsImageVisible(false);
@@ -18,7 +23,7 @@ export const PrizeResult = (props: PrizeResultProps) => {
       <div className={styles.container}>
         <div className={styles.frame_title}>
           <Image src="/GiftBox.svg" alt="GiftBox" width={19} height={19} />
-          Prize List
+          {t.SUB_TITLE_PRIZE}
         </div>
         <div id="loading" className={isImageVisible ? styles.visible : styles.hidden}></div>
         <div className={styles.card_frame}>
@@ -50,7 +55,7 @@ export const PrizeResult = (props: PrizeResultProps) => {
                 </div>
                 {prizeResult.existing && (
                   <div className={styles.overlay}>
-                    <p>当選！</p>
+                    <p>{t.WINNING_OVERRAY}</p>
                   </div>
                 )}
               </div>

--- a/view-user/src/pages/index.tsx
+++ b/view-user/src/pages/index.tsx
@@ -5,8 +5,12 @@ import Image from "next/image";
 import styles from "@/styles/Home.module.css";
 import { Header, Modal, BingoResult, Button } from "@/components/common";
 import { useRouter } from "next/router";
+import { ja } from "./locales/ja";
+import { en } from "./locales/en";
 
 const Page: NextPage = () => {
+  const { locale } = useRouter()
+  const t = locale === "ja" ? ja : en;
   const [isOpened, setIsOpened] = useState(false);
   const router = useRouter();
   const isopenBool = () => setIsOpened(!isOpened);
@@ -43,7 +47,7 @@ const Page: NextPage = () => {
                 width={19}
                 height={19}
               />
-              Prize
+              {t.PRIZE_BUTTON}
             </div>
           </Button>
           <button type="button" onClick={isopenBool} className={styles.btnOpen}>

--- a/view-user/src/pages/index.tsx
+++ b/view-user/src/pages/index.tsx
@@ -11,10 +11,33 @@ import { en } from "./locales/en";
 const Page: NextPage = () => {
   const { locale } = useRouter()
   const t = locale === "ja" ? ja : en;
-  const [isOpened, setIsOpened] = useState(false);
+  const [isOpened, setIsOpened] = useState(true);
   const router = useRouter();
   const isopenBool = () => setIsOpened(!isOpened);
   const [bingoNumbers, setBingoNumbers] = useState<BingoNumber[]>([]);
+
+  useEffect(() => {
+    const storedIsOpened = localStorage.getItem("isOpened");
+    if (storedIsOpened !== null) {
+      setIsOpened(JSON.parse(storedIsOpened));
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem("isOpened", JSON.stringify(isOpened));
+  }, [isOpened]);
+
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      localStorage.removeItem("isOpened");
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, []);
 
   useEffect(() => {
     async function fetchBingoNumbers() {
@@ -34,8 +57,16 @@ const Page: NextPage = () => {
   return (
     <div className={styles.container}>
       <Modal isOpened={isOpened} setisOpened={setIsOpened}>
-        抽選された番号
-        <p></p>
+        <div className={styles.languageBlock}>
+          <p onClick={() => {
+            router.push("/", "/", {locale: "ja"})
+            setIsOpened(false);
+          }}>日本語</p>
+          <p onClick={() => {
+            router.push("/", "/", {locale: "en"})
+            setIsOpened(false);
+            }}>English</p>
+        </div>
       </Modal>
       <Header user="">
         <div className={styles.main}>

--- a/view-user/src/pages/index.tsx
+++ b/view-user/src/pages/index.tsx
@@ -81,9 +81,6 @@ const Page: NextPage = () => {
               {t.PRIZE_BUTTON}
             </div>
           </Button>
-          <button type="button" onClick={isopenBool} className={styles.btnOpen}>
-            最新の番号を表示
-          </button>
         </div>
       </Header>
       <BingoResult bingoResultNumber={bingoNumbers} />

--- a/view-user/src/pages/index.tsx
+++ b/view-user/src/pages/index.tsx
@@ -58,14 +58,26 @@ const Page: NextPage = () => {
     <div className={styles.container}>
       <Modal isOpened={isOpened} setisOpened={setIsOpened}>
         <div className={styles.languageBlock}>
-          <p onClick={() => {
-            router.push("/", "/", {locale: "ja"})
-            setIsOpened(false);
-          }}>日本語</p>
-          <p onClick={() => {
-            router.push("/", "/", {locale: "en"})
-            setIsOpened(false);
-            }}>English</p>
+            <div className={styles.language}>
+              <p
+                onClick={() => {
+                  router.push('/', '/', { locale: 'ja' });
+                  setIsOpened(false);
+                }}
+              >
+                日本語
+              </p>
+            </div>
+            <div className={styles.language}>
+              <p
+                onClick={() => {
+                  router.push('/', '/', { locale: 'en' });
+                  setIsOpened(false);
+                }}
+              >
+                English
+              </p>
+            </div>
         </div>
       </Modal>
       <Header user="">

--- a/view-user/src/pages/index.tsx
+++ b/view-user/src/pages/index.tsx
@@ -7,6 +7,7 @@ import { Header, Modal, BingoResult, Button } from "@/components/common";
 import { useRouter } from "next/router";
 import { ja } from "./locales/ja";
 import { en } from "./locales/en";
+import { MdTranslate } from "react-icons/md";
 
 const Page: NextPage = () => {
   const { locale } = useRouter()
@@ -96,6 +97,11 @@ const Page: NextPage = () => {
         </div>
       </Header>
       <BingoResult bingoResultNumber={bingoNumbers} />
+      <Button size="null" shape="null" onClick={() => setIsOpened(true)}>
+        <div className={styles.iconButton}>
+          <MdTranslate size={35} />
+        </div>
+      </Button>
     </div>
   );
 };

--- a/view-user/src/pages/index.tsx
+++ b/view-user/src/pages/index.tsx
@@ -14,7 +14,6 @@ const Page: NextPage = () => {
   const t = locale === "ja" ? ja : en;
   const [isOpened, setIsOpened] = useState(true);
   const router = useRouter();
-  const isopenBool = () => setIsOpened(!isOpened);
   const [bingoNumbers, setBingoNumbers] = useState<BingoNumber[]>([]);
 
   useEffect(() => {

--- a/view-user/src/pages/index.tsx
+++ b/view-user/src/pages/index.tsx
@@ -16,6 +16,7 @@ const Page: NextPage = () => {
   const router = useRouter();
   const [bingoNumbers, setBingoNumbers] = useState<BingoNumber[]>([]);
 
+  // 最初のrendrer時だけ実行してモーダルの再表示を防止する。
   useEffect(() => {
     const storedIsOpened = localStorage.getItem("isOpened");
     if (storedIsOpened !== null) {
@@ -23,10 +24,13 @@ const Page: NextPage = () => {
     }
   }, []);
 
+  // isOpenedの状態をもとにlocalStorageを更新する。
+  // localStorageにbooleanが保存できないため、json形式に変換して保存する。
   useEffect(() => {
     localStorage.setItem("isOpened", JSON.stringify(isOpened));
   }, [isOpened]);
 
+  // ページのリロード前にlocalStorageを削除する。
   useEffect(() => {
     const handleBeforeUnload = () => {
       localStorage.removeItem("isOpened");

--- a/view-user/src/pages/locales/en.ts
+++ b/view-user/src/pages/locales/en.ts
@@ -1,0 +1,9 @@
+export const en = {
+  PRIZE_BUTTON: "Prize",
+  NUMBER_BUTTON: "Number",
+  SUB_TITLE_NUMBER: "BINGO Number",
+  SUB_TITLE_PRIZE: "Prize List",
+  NUMBER_ORDER_BUTTON: "Num Order",
+  LOTTERY_ORDER_BUTTON: "Lott Order",
+  WINNING_OVERRAY: "Won!",
+}

--- a/view-user/src/pages/locales/ja.ts
+++ b/view-user/src/pages/locales/ja.ts
@@ -1,0 +1,9 @@
+export const ja = {
+  PRIZE_BUTTON: "景品",
+  NUMBER_BUTTON: "番号一覧",
+  SUB_TITLE_NUMBER: "BINGO Number",
+  SUB_TITLE_PRIZE: "景品一覧",
+  NUMBER_ORDER_BUTTON: "番号順",
+  LOTTERY_ORDER_BUTTON: "抽選順",
+  WINNING_OVERRAY: "当選！",
+}

--- a/view-user/src/pages/locales/ja.ts
+++ b/view-user/src/pages/locales/ja.ts
@@ -1,7 +1,7 @@
 export const ja = {
   PRIZE_BUTTON: "景品",
   NUMBER_BUTTON: "番号一覧",
-  SUB_TITLE_NUMBER: "BINGO Number",
+  SUB_TITLE_NUMBER: "抽選された番号",
   SUB_TITLE_PRIZE: "景品一覧",
   NUMBER_ORDER_BUTTON: "番号順",
   LOTTERY_ORDER_BUTTON: "抽選順",

--- a/view-user/src/pages/prizes/index.tsx
+++ b/view-user/src/pages/prizes/index.tsx
@@ -9,8 +9,12 @@ import {
   subscriptionBingoPrize,
   getBingoPrize,
 } from "@/utils/api_methods";
+import { ja } from "../locales/ja";
+import { en } from "../locales/en";
 
 const Page: NextPage = () => {
+  const { locale } = useRouter()
+  const t = locale === "ja" ? ja : en;
   const router = useRouter();
   const [bingoPrize, setBingoPrize] = useState<BingoPrize[]>([]); // get
 
@@ -62,7 +66,7 @@ const Page: NextPage = () => {
                 width={25}
                 height={25}
               />
-              Number
+              {t.NUMBER_BUTTON}
             </div>
           </Button>
         </div>

--- a/view-user/src/styles/Home.module.css
+++ b/view-user/src/styles/Home.module.css
@@ -10,6 +10,18 @@
   padding: 0.5rem 1rem;
 }
 
+.languageBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  color:#D95B7F;
+  font-size: clamp(2rem, calc(100vw / 20 ) , 3rem);
+}
+
+.languageBlock p {
+  background-color: #07033E;
+}
+
 .btnOpen {
   padding: 0.9em 2em;
   border: 0.2rem solid #fff;

--- a/view-user/src/styles/Home.module.css
+++ b/view-user/src/styles/Home.module.css
@@ -15,30 +15,19 @@
   flex-direction: column;
   gap: 0.5rem;
   color:#D95B7F;
-  font-size: clamp(3rem, calc(100vw / 20 ) , 5rem);
+  font-size: clamp(2.5rem, calc(100vw / 20 ) , 5rem);
+}
+
+.language {
+  display: flex;
+  justify-content: center;
+  background-color: #07033E;
+  padding: 0.5rem 1.5rem;
+  border-radius: 0.5rem;
 }
 
 .languageBlock p {
   background-color: #07033E;
-}
-
-.btnOpen {
-  padding: 0.9em 2em;
-  border: 0.2rem solid #fff;
-  border-radius: 0.5rem;
-  box-shadow: 0 0 0 0.2rem #333333;
-  background-color: #333333;
-  color: #fff;
-  font-weight: 600;
-  font-size: 1rem;
-  margin-right: 1rem;
-  white-space:nowrap;
-}
-
-.btnOpen:hover {
-  background-color: whitesmoke;
-  color: var(--primary);
-  transition: 0.25s;
 }
 
 .main {
@@ -59,6 +48,24 @@
   align-items: center;
   justify-content: center;
   gap: 0.3rem;
+}
+
+.iconButton {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  width: 4.5rem;
+  height: 4.5rem;
+  color: #D95B7F;
+  border: solid 0.13rem #ffffffd5;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  background-color: rgba(18, 36, 99, 1);
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
+  z-index: 1;
 }
 
 @media screen and (max-width: 900px) {

--- a/view-user/src/styles/Home.module.css
+++ b/view-user/src/styles/Home.module.css
@@ -15,7 +15,7 @@
   flex-direction: column;
   gap: 0.5rem;
   color:#D95B7F;
-  font-size: clamp(2rem, calc(100vw / 20 ) , 3rem);
+  font-size: clamp(3rem, calc(100vw / 20 ) , 5rem);
 }
 
 .languageBlock p {


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #154 

# 概要
<!-- 開発内容の概要を記載 -->

- ユーザーページの多言語対応化を行った。

# 実装詳細
<!-- 具体的な開発内容を記載 -->

- Next.jsのInternationalization (i18n) Routingを利用することで、ユーザーページにアクセスした際に「日本語・英語」から言語を選択できるようにしました。

- Modalコンポーネントが初期状態で放置されていたため、CSSを刷新しました。

- 言語選択モーダルの表示はページにアクセスした最初だけ必要であるため、LocalStorageを利用してState管理するようにしました。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->

### 言語選択モーダル
|  |  |
| ---- | ---- |
|![FireShot Capture 133 - Bingo - localhost](https://github.com/NUTFes/nutfes-Bingo/assets/131145590/ee72d8f4-7a4c-4c6f-8fbd-5dcfb7102e85)|![FireShot Capture 134 - Bingo - localhost](https://github.com/NUTFes/nutfes-Bingo/assets/131145590/bcd6e0f9-d8e8-4da7-8439-0551315b8a1f)|

### 番号表示ページ


![FireShot Capture 122 - Bingo - localhost](https://github.com/NUTFes/nutfes-Bingo/assets/131145590/c968ad39-2f72-4a58-84a5-09b01d150a97)![FireShot Capture 119 - Bingo - localhost](https://github.com/NUTFes/nutfes-Bingo/assets/131145590/c3f0f90b-765d-4252-b241-206058e542ac)

### 景品表示ページ
![FireShot Capture 126 - Bingo - localhost](https://github.com/NUTFes/nutfes-Bingo/assets/131145590/e1a99817-77c3-4bcf-a3ee-ab14920b114d)![FireShot Capture 121 - Bingo - localhost](https://github.com/NUTFes/nutfes-Bingo/assets/131145590/6ef060f5-4b7d-45dd-b9b0-9c0a51640a12)


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->

- [ ] localhost:3000にアクセスすると、言語選択モーダルが表示される。
- [ ] 日本語を選択すると、日本語のページが表示される。
- [ ] 英語を選択すると、英語のページが表示される。
- [ ] 番号表示ページ ⇔ 景品表示ページ の互いの遷移で言語選択モーダルが再表示されない。
- [ ] ブラウザでリロードすると言語選択モーダルが再表示される。

# 備考
<!-- 実装していて困った箇所・質問など -->
参考：https://nextjs.org/docs/pages/building-your-application/routing/internationalization
