### PR TITLE
景品ページに言語切り替えボタンを追加

### DIFF
--- a/view-user/src/pages/prizes/index.tsx
+++ b/view-user/src/pages/prizes/index.tsx
@@ -1,7 +1,7 @@
 import type { NextPage } from "next";
 import styles from "./prizes.module.css";
 import Image from "next/image";
-import { Header, Button, PrizeResult } from "@/components/common";
+import { Header, Button, PrizeResult, Modal } from "@/components/common";
 import { useRouter } from "next/router";
 import { useState, useEffect } from "react";
 import {
@@ -11,10 +11,12 @@ import {
 } from "@/utils/api_methods";
 import { ja } from "../locales/ja";
 import { en } from "../locales/en";
+import { MdTranslate } from "react-icons/md";
 
 const Page: NextPage = () => {
   const { locale } = useRouter()
   const t = locale === "ja" ? ja : en;
+  const [isOpened, setIsOpened] = useState(false);
   const router = useRouter();
   const [bingoPrize, setBingoPrize] = useState<BingoPrize[]>([]); // get
 
@@ -56,6 +58,30 @@ const Page: NextPage = () => {
 
   return (
     <div className={styles.container}>
+      <Modal isOpened={isOpened} setisOpened={setIsOpened}>
+        <div className={styles.languageBlock}>
+            <div className={styles.language}>
+              <p
+                onClick={() => {
+                  router.push('/prizes', '/prizes', { locale: 'ja' });
+                  setIsOpened(false);
+                }}
+              >
+                日本語
+              </p>
+            </div>
+            <div className={styles.language}>
+              <p
+                onClick={() => {
+                  router.push('/prizes', '/prizes', { locale: 'en' });
+                  setIsOpened(false);
+                }}
+              >
+                English
+              </p>
+            </div>
+        </div>
+      </Modal>
       <Header user="">
         <div className={styles.main}>
           <Button size="m" shape="circle" onClick={() => router.push("/")}>
@@ -72,6 +98,11 @@ const Page: NextPage = () => {
         </div>
       </Header>
       <PrizeResult prizeResult={bingoPrize} />
+      <Button size="null" shape="null" onClick={() => setIsOpened(true)}>
+        <div className={styles.iconButton}>
+          <MdTranslate size={35} />
+        </div>
+      </Button>
     </div>
   );
 };

--- a/view-user/src/pages/prizes/prizes.module.css
+++ b/view-user/src/pages/prizes/prizes.module.css
@@ -4,24 +4,24 @@
     overflow: auto;
     background: linear-gradient(180deg, #d95b7f 0%, #856db2 23.96%, #07033e 100%);
   }
-  
+
   .main {
     display: flex;
     align-items: center;
     margin-right: 0.8rem;
   }
-  
+
   .buttonContents {
     display: flex;
     align-items: center;
     justify-content: center;
     gap: 0.3rem;
   }
-  
+
   .buttonContents img {
     color: #FFF;
   }
-  
+
   .title {
       display: flex;
       justify-content: center;
@@ -29,4 +29,41 @@
       gap: 0.3rem;
       margin-top: 0.8rem;
   }
-  
+
+  .iconButton {
+    position: fixed;
+    right: 1rem;
+    bottom: 1rem;
+    width: 4.5rem;
+    height: 4.5rem;
+    color: #D95B7F;
+    border: solid 0.13rem #ffffffd5;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    background-color: rgba(18, 36, 99, 1);
+    box-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
+    z-index: 1;
+  }
+
+  .languageBlock {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    color:#D95B7F;
+    font-size: clamp(2.5rem, calc(100vw / 20 ) , 5rem);
+  }
+
+  .language {
+    display: flex;
+    justify-content: center;
+    background-color: #07033E;
+    padding: 0.5rem 1.5rem;
+    border-radius: 0.5rem;
+  }
+
+  .languageBlock p {
+    background-color: #07033E;
+  }


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #156 

# 概要
<!-- 開発内容の概要を記載 -->


# 実装詳細
<!-- 具体的な開発内容を記載 -->
景品ページに番号表示ページと同様の言語切り替えボタンを実装する。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
|||
| ---- | ---- |
|![FireShot Capture 141 - Bingo - localhost](https://github.com/NUTFes/nutfes-Bingo/assets/131145590/3b90027c-6aab-423b-8f91-539c67ae85af)|![FireShot Capture 142 - Bingo - localhost](https://github.com/NUTFes/nutfes-Bingo/assets/131145590/8813ae4a-ad6f-4efb-9862-a2cfbf1209c4)|


# テスト

項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [ ] 景品ページに言語切り替えボタンがある。
- [ ] 言語切り替えボタンを押すとモーダルが表示される。
- [ ] 言語を選択して言語が切り替わる。

# 備考
<!-- 実装していて困った箇所・質問など -->
