### PR TITLE
PrizeCardコンポーネントの実装

### DIFF
--- a/view-user/src/components/common/PrizeCard/PrizeCard.module.css
+++ b/view-user/src/components/common/PrizeCard/PrizeCard.module.css
@@ -36,7 +36,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  border-radius: 3.125vw;
+  border-radius: 1.8vw;
   background-color: rgba(0, 0, 0, 0.4);
 }
 

--- a/view-user/src/components/common/PrizeCard/PrizeCard.module.css
+++ b/view-user/src/components/common/PrizeCard/PrizeCard.module.css
@@ -1,0 +1,57 @@
+.container {
+  display: flex;
+  flex-direction: column;
+}
+
+.card {
+  /* TODO　cardのみにオーバレイがかかっているがどうするべきか意見が欲しい。 */
+  position: relative;
+  width: 25vw;
+  height: 25vw;
+  border: 1.25vw solid #ff3342;
+  border-radius: 3.125vw;
+  box-sizing: border-box;
+  box-shadow: 0.9375vw 0.9375vw 0px #ff3342;
+}
+
+.image {
+  /* TODO　画像の丸みとカードの丸みが合わない。。。 */
+  overflow: hidden;
+  width: 100%;
+  height: 100%;
+  border-radius: 2vw;
+  margin-bottom: 2.5vw;
+}
+
+.text {
+  color: #ff3342;
+  font-family: "Noto Sans JP";
+  font-size: 2.8125vw;
+  font-weight: 500;
+}
+
+.overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 3.125vw;
+  background-color: rgba(0, 0, 0, 0.4);
+}
+
+.overlay p {
+  line-height: 1.8;
+  width: 100%;
+  font-size: 4vw;
+  font-weight: 700;
+  color: #ff3342;
+  background-color: #07033e;
+}
+
+/* 中央配置使いまわす用 */
+.center {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/view-user/src/components/common/PrizeCard/PrizeCard.module.css
+++ b/view-user/src/components/common/PrizeCard/PrizeCard.module.css
@@ -4,7 +4,6 @@
 }
 
 .card {
-  /* TODO　cardのみにオーバレイがかかっているがどうするべきか意見が欲しい。 */
   position: relative;
   width: 25vw;
   height: 25vw;
@@ -15,7 +14,6 @@
 }
 
 .image {
-  /* TODO　画像の丸みとカードの丸みが合わない。。。 */
   overflow: hidden;
   width: 100%;
   height: 100%;
@@ -31,6 +29,7 @@
 }
 
 .overlay {
+  /* TODO オーバーレイのcssを改良する */
   position: absolute;
   top: 0;
   left: 0;

--- a/view-user/src/components/common/PrizeCard/PrizeCard.tsx
+++ b/view-user/src/components/common/PrizeCard/PrizeCard.tsx
@@ -41,7 +41,6 @@ const PrizeCard = (props: PrizeCardProps) => {
               objectFit: "cover",
               width: "100%",
               height: "100%",
-              borderRadius: "3.125vw",
             }}
           />
         </div>

--- a/view-user/src/components/common/PrizeCard/PrizeCard.tsx
+++ b/view-user/src/components/common/PrizeCard/PrizeCard.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import styles from "./PrizeCard.module.css";
+import { BingoPrize } from "@/type/common";
+import { useRouter } from "next/router";
+import { ja } from "@/locales/ja";
+import { en } from "@/locales/en";
+import classNames from "classnames";
+
+interface PrizeCardProps {
+  BingoPrize: BingoPrize;
+}
+
+const PrizeCard = (props: PrizeCardProps) => {
+  // TODO lacaleでnameJpとnameEnの切り替えを実装する。
+  // nameEnがない場合はnameJpを表示
+  const { locale } = useRouter();
+  const t = locale === "ja" ? ja : en;
+
+  const bingoPrize = props.BingoPrize;
+  const prizeImage = bingoPrize.prizeImage;
+
+  const imageURL: string = prizeImage
+    ? `${process.env.NEXT_PUBLIC_MINIO_ENDPONT}/${prizeImage.bucketName}/${prizeImage.fileName}`
+    : "";
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.card}>
+        <div
+          className={styles.image}
+          style={{
+            position: "relative",
+            width: "100%",
+            height: "100%",
+          }}
+        >
+          <img
+            src={imageURL}
+            alt="PrizeImage"
+            style={{
+              objectFit: "cover",
+              width: "100%",
+              height: "100%",
+              borderRadius: "3.125vw",
+            }}
+          />
+        </div>
+        <div
+          style={{ position: "relative" }}
+          className={classNames(styles.text, styles.center)}
+        >
+          {bingoPrize.nameJp}
+        </div>
+        {bingoPrize.isWon && (
+          <div className={classNames(styles.overlay, styles.center)}>
+            <p className={styles.center}>{t.WINNING_OVERRAY}</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PrizeCard;

--- a/view-user/src/components/common/PrizeCard/index.ts
+++ b/view-user/src/components/common/PrizeCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./PrizeCard";

--- a/view-user/src/components/common/index.ts
+++ b/view-user/src/components/common/index.ts
@@ -8,3 +8,4 @@ export { default as Button } from "./Button";
 export { default as BingoIcon } from "./BingoIcon";
 export { default as PrizeResult } from "./PrizeResult";
 export { default as NumberCardSmall } from "./NumberCardSmall";
+export { default as PrizeCard } from "./PrizeCard";

--- a/view-user/src/pages/test/index.tsx
+++ b/view-user/src/pages/test/index.tsx
@@ -1,6 +1,6 @@
 // pages/index.tsx
 import React from "react";
-import { NumberCardSmall } from "@/components/common";
+import { NumberCardSmall, PrizeCard } from "@/components/common";
 
 const testBingoNumber = {
   id: 17,
@@ -8,11 +8,30 @@ const testBingoNumber = {
   createdAt: "2024-08-01",
   updatedAt: "2024-08-01",
 };
+const testPrizeImage = {
+  id: 17,
+  bucketName: "bingo",
+  fileName: "クラス図0.png",
+  fileType: "image/png",
+  createdAt: "2024-8-6",
+  updatedAt: "2024-8-6",
+};
+const testBingoPrize = {
+  id: 17,
+  nameJp: "nameJpです",
+  nameEn: "nameEnです",
+  isWon: true,
+  imageId: 17,
+  createdAt: "2024-8-6",
+  updatedAt: "2024-8-6",
+  prizeImage: testPrizeImage,
+};
 
 const HomePage: React.FC = () => {
   return (
     <div>
-      <NumberCardSmall BingoNumber={testBingoNumber}></NumberCardSmall>
+      {/* <NumberCardSmall BingoNumber={testBingoNumber}></NumberCardSmall> */}
+      <PrizeCard BingoPrize={testBingoPrize}></PrizeCard>
     </div>
   );
 };


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #214

# 概要
<!-- 開発内容の概要を記載 -->
PrizeCardコンポーネントの実装を実装しました、
テストページで呼び出しています。

# 実装詳細
<!-- 具体的な開発内容を記載 -->
components/commonに新しくPrizeCardフォルダを作成し、コンポーネントを実装しました。
画面幅320pxに対してのvwを設定しました。
オーバレイのテキストに関しては375px時に15pxくらいになるようにvwを設定しました。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
![image](https://github.com/user-attachments/assets/5392743a-99e4-426f-89ce-57164f71153f)


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [x] 動作確認 propsを変えると変わるか
- [x] 画面幅に対して可変的に変動するか
- [x] ほか触ってみてへんなところがないか
- [x] figmaと比較してください

# 備考
<!-- 実装していて困った箇所・質問など -->
えと、cardにborder-radious設定したら隙間できちゃって困ってます。。。。
オーバーレイがかかるのがcardのみですがどうでしょうか？？なんかもうちょっと変更した方いいでしょうか。