### PR TITLE
NavigationBarとレイアウトの作成

### DIFF
--- a/view-user/src/components/Layout/Layout.tsx
+++ b/view-user/src/components/Layout/Layout.tsx
@@ -42,7 +42,7 @@ const Layout = (props: LayoutProps) => {
     localStorage.setItem("isReachIconVisible", "false");
   };
 
-  const Icons = (pageName: any) => {
+  const Icons = (pageName: string) => {
     let icons = [];
     switch (pageName) {
       case "/":

--- a/view-user/src/components/Layout/Layout.tsx
+++ b/view-user/src/components/Layout/Layout.tsx
@@ -1,0 +1,92 @@
+import React, { useState, useEffect } from "react";
+import {
+  ReachIcon,
+  NavigationBar,
+  PrizesIcon,
+  ReactionStampModal,
+  Header,
+} from "@/components/common";
+
+const images = [
+  { src: "/ReactionIcon/crap.png", alt: "crap icon" },
+  { src: "/ReactionIcon/good.png", alt: " good icon" },
+  { src: "/ReactionIcon/cracker.png", alt: "cracker icon" },
+  { src: "/ReactionIcon/heart.png", alt: "heart icon" },
+  { src: "/ReactionIcon/smile.png", alt: "smile icon" },
+  { src: "/ReactionIcon/angry.png", alt: "angry icon" },
+  { src: "/ReactionIcon/skull.png", alt: "skull icon" },
+  { src: "/ReactionIcon/sad.png", alt: "sad icon" },
+];
+
+const testPosition: string = "50%";
+
+interface LayoutProps {
+  children: React.ReactNode;
+  pageName: string;
+}
+
+const Layout = (props: LayoutProps) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const [isReachIconVisible, setReachIconVisible] = useState(true);
+
+  // 初回レンダリング時に localStorage から状態を読み込む
+  useEffect(() => {
+    const storedVisibility = localStorage.getItem("isReachIconVisible");
+    if (storedVisibility !== null) {
+      setReachIconVisible(storedVisibility === "true");
+    }
+  }, []);
+
+  const handleReachIconClick = () => {
+    setReachIconVisible(false);
+    localStorage.setItem("isReachIconVisible", "false");
+  };
+
+  const Icons = (pageName: any) => {
+    switch (pageName) {
+      case "/":
+        return (
+          <>
+            {/* todo Prizes,reactions, reach,settings */}
+            <PrizesIcon />
+            <PrizesIcon />
+            {isReachIconVisible && <ReachIcon onClick={handleReachIconClick} />}
+            <PrizesIcon />
+          </>
+        );
+      case "/prizes":
+        return (
+          <>
+            {/* todo back,reactions, reach,settings */}
+            <PrizesIcon />
+            {isReachIconVisible && <ReachIcon onClick={handleReachIconClick} />}
+            <PrizesIcon />
+            <PrizesIcon />
+          </>
+        );
+      default:
+        return (
+          <>
+            <PrizesIcon />
+            {isReachIconVisible && <ReachIcon onClick={handleReachIconClick} />}
+            <PrizesIcon />
+            <PrizesIcon />
+          </>
+        );
+    }
+  };
+
+  return (
+    <div>
+      <Header />
+      <main>{props.children}</main>
+      {isModalOpen && (
+        <ReactionStampModal position={testPosition} images={images} />
+      )}
+      <NavigationBar>{Icons(props.pageName)}</NavigationBar>
+    </div>
+  );
+};
+
+export default Layout;

--- a/view-user/src/components/Layout/Layout.tsx
+++ b/view-user/src/components/Layout/Layout.tsx
@@ -27,7 +27,6 @@ interface LayoutProps {
 
 const Layout = (props: LayoutProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
-
   const [isReachIconVisible, setReachIconVisible] = useState(true);
 
   // 初回レンダリング時に localStorage から状態を読み込む
@@ -44,38 +43,44 @@ const Layout = (props: LayoutProps) => {
   };
 
   const Icons = (pageName: any) => {
+    let icons = [];
     switch (pageName) {
       case "/":
-        return (
-          <>
-            {/* todo Prizes,reactions, reach,settings */}
-            <PrizesIcon />
-            <PrizesIcon />
-            {isReachIconVisible && <ReachIcon onClick={handleReachIconClick} />}
-            <PrizesIcon />
-          </>
-        );
+        // todoprizes,reactions,reach,settings
+        icons = [
+          <PrizesIcon key="prize1" />,
+          <PrizesIcon key="prize2" />,
+          isReachIconVisible && (
+            <ReachIcon key="reach" onClick={handleReachIconClick} />
+          ),
+          <PrizesIcon key="prize3" />,
+        ];
+        break;
       case "/prizes":
-        return (
-          <>
-            {/* todo back,reactions, reach,settings */}
-            <PrizesIcon />
-            {isReachIconVisible && <ReachIcon onClick={handleReachIconClick} />}
-            <PrizesIcon />
-            <PrizesIcon />
-          </>
-        );
+        // todo back,reactions, reach,settings
+        icons = [
+          <PrizesIcon key="prize1" />,
+          isReachIconVisible && (
+            <ReachIcon key="reach" onClick={handleReachIconClick} />
+          ),
+          <PrizesIcon key="prize2" />,
+          <PrizesIcon key="prize3" />,
+        ];
+        break;
       default:
-        return (
-          <>
-            <PrizesIcon />
-            {isReachIconVisible && <ReachIcon onClick={handleReachIconClick} />}
-            <PrizesIcon />
-            <PrizesIcon />
-          </>
-        );
+        icons = [
+          <PrizesIcon key="prize1" />,
+          isReachIconVisible && (
+            <ReachIcon key="reach" onClick={handleReachIconClick} />
+          ),
+          <PrizesIcon key="prize2" />,
+          <PrizesIcon key="prize3" />,
+        ];
     }
+    return icons.filter(Boolean);
   };
+
+  const iconElements = Icons(props.pageName);
 
   return (
     <div>
@@ -84,7 +89,9 @@ const Layout = (props: LayoutProps) => {
       {isModalOpen && (
         <ReactionStampModal position={testPosition} images={images} />
       )}
-      <NavigationBar>{Icons(props.pageName)}</NavigationBar>
+      <NavigationBar isCentered={iconElements.length <= 3}>
+        {iconElements}
+      </NavigationBar>
     </div>
   );
 };

--- a/view-user/src/components/Layout/index.ts
+++ b/view-user/src/components/Layout/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Layout";

--- a/view-user/src/components/common/NavigationBar/NavigationBar.module.css
+++ b/view-user/src/components/common/NavigationBar/NavigationBar.module.css
@@ -1,0 +1,12 @@
+.navigationBar {
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  padding: 10px 20px;
+  background-color: white;
+  box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.1);
+}

--- a/view-user/src/components/common/NavigationBar/NavigationBar.module.css
+++ b/view-user/src/components/common/NavigationBar/NavigationBar.module.css
@@ -1,12 +1,17 @@
 .navigationBar {
   display: flex;
-  justify-content: space-evenly;
+  justify-content: space-between;
   align-items: center;
   position: fixed;
   bottom: 0;
   left: 0;
   width: 100%;
-  padding: 10px 20px;
+  padding: 3.125vw 6.25vw;
   background-color: white;
-  box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 -0.625vw 3.125vw rgba(0, 0, 0, 0.1);
+}
+
+.center {
+  justify-content: center;
+  gap: 5vw;
 }

--- a/view-user/src/components/common/NavigationBar/NavigationBar.tsx
+++ b/view-user/src/components/common/NavigationBar/NavigationBar.tsx
@@ -1,11 +1,20 @@
 import React from "react";
+import classNames from "classnames";
 import styles from "./NavigationBar.module.css";
 
 interface NavigationBarProps {
   children: React.ReactNode;
+  isCentered: boolean;
 }
-const NavigationBar = (props: NavigationBarProps) => {
-  return <div className={styles.navigationBar}>{props.children}</div>;
+
+const NavigationBar = ({ children, isCentered }: NavigationBarProps) => {
+  return (
+    <div className={classNames(styles.navigationBar, {
+      [styles.center]: isCentered,
+    })}>
+      {children}
+    </div>
+  );
 };
 
 export default NavigationBar;

--- a/view-user/src/components/common/NavigationBar/NavigationBar.tsx
+++ b/view-user/src/components/common/NavigationBar/NavigationBar.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import styles from "./NavigationBar.module.css";
+
+interface NavigationBarProps {
+  children: React.ReactNode;
+}
+const NavigationBar = (props: NavigationBarProps) => {
+  return <div className={styles.navigationBar}>{props.children}</div>;
+};
+
+export default NavigationBar;

--- a/view-user/src/components/common/NavigationBar/index.ts
+++ b/view-user/src/components/common/NavigationBar/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NavigationBar";

--- a/view-user/src/components/common/ReachIcon/ReachIcon.tsx
+++ b/view-user/src/components/common/ReachIcon/ReachIcon.tsx
@@ -3,10 +3,15 @@ import styles from "./ReachIcon.module.css";
 import classNames from "classnames";
 import Image from "next/image";
 
-const ReachIcon = () => {
+interface ReachIconProps {
+  onClick: () => void;
+}
+
+const ReachIcon = (props: ReachIconProps) => {
   const [colorInversion, setColorInversion] = useState<boolean>(false);
   const handleClick = () => {
     setColorInversion(!colorInversion);
+    props.onClick();
     //TODO 後でモーダルの開閉を追加する
   };
   return (

--- a/view-user/src/components/common/index.ts
+++ b/view-user/src/components/common/index.ts
@@ -17,3 +17,4 @@ export { default as NumberCardList } from "./NumberCardList";
 export { default as ReactionStampModal } from "./ReactionStampModal";
 export { default as ToggleButton } from "./ToggleButton";
 export { default as ReachIcon } from "./ReachIcon";
+export { default as NavigationBar } from "./NavigationBar";

--- a/view-user/src/pages/test/index.tsx
+++ b/view-user/src/pages/test/index.tsx
@@ -6,8 +6,12 @@ import {
   ReachIcon,
   PrizeCardList,
   PrizeCard,
+  NavigationBar,
+  PrizesIcon,
 } from "@/components/common";
+import Layout from "@/components/Layout";
 import { BingoNumber, BingoPrize, PrizeImage } from "@/type/common";
+import { useRouter } from "next/router";
 
 const testBingoNumbers: BingoNumber[] = [
   { id: 1, number: 1, createdAt: "2024-08-01", updatedAt: "2024-08-01" },
@@ -21,25 +25,9 @@ const testBingoNumbers: BingoNumber[] = [
   { id: 9, number: 9, createdAt: "2024-08-01", updatedAt: "2024-08-01" },
 ];
 
-const images = [
-  { src: "/ReactionIcon/crap.png", alt: "crap icon" },
-  { src: "/ReactionIcon/good.png", alt: " good icon" },
-  { src: "/ReactionIcon/cracker.png", alt: "cracker icon" },
-  { src: "/ReactionIcon/heart.png", alt: "heart icon" },
-  { src: "/ReactionIcon/smile.png", alt: "smile icon" },
-  { src: "/ReactionIcon/angry.png", alt: "angry icon" },
-  { src: "/ReactionIcon/skull.png", alt: "skull icon" },
-  { src: "/ReactionIcon/surprise.png", alt: "surprise icon" },
-];
-
-const testPosition: string = "50%";
-
 const HomePage: React.FC = () => {
-  const [isModalOpen, setIsModalOpen] = useState(false);
-
-  const toggleModal = () => {
-    setIsModalOpen(!isModalOpen);
-  };
+  const router = useRouter();
+  const pageName = router.pathname;
 
   return (
     <div>
@@ -50,10 +38,12 @@ const HomePage: React.FC = () => {
       {isModalOpen && (
         <ReactionStampModal position={testPosition} images={images} />
       )} */}
-      <ReachIcon />
-      <PrizeCardList BingoPrize={testBingoPrizes} />
+      {/* <ReachIcon /> */}
+      {/* <PrizeCardList BingoPrize={testBingoPrizes} /> */}
+      <Layout pageName={pageName}>hello</Layout>
     </div>
   );
 };
 
 export default HomePage;
+


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #247

# 概要
<!-- 開発内容の概要を記載 -->
NavigationBarの作成をしました。
また、それに伴い、レイアウトも作成しました。
# 実装詳細
<!-- 具体的な開発内容を記載 -->
conponents/commonにNavigationBarを作成しました。
components/layoutを新たに作成し、ヘッダーとナムバーを合体させたものを作成しました。
pathnameで表示するアイコンを変えるようにしています。`/`と`/prizes`です。しかし、テストページにあるのはdefaultにあるものが表示されます。
また、reachIconを押すと非表示になるようにしてlocalstorageで管理するようにしてみました。
リーチしましたか？→はいをクリックした際に修正予定ですが、動作としてナムバーが良い感じが見てほしいです。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
![image](https://github.com/user-attachments/assets/ab06d09e-1f17-4c14-a5b2-e87f65f917f5)


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [x] 動作確認いい感じか
- [x] 下の後備多いですがご一読を。。。
- [ ] 

# 備考
<!-- 実装していて困った箇所・質問など -->
branch名をミスって切ってました`creater-navbar`になってます。
まだReactionsIconやbackIcon,settingsがマージされてないのでとりあえずprizesIconを敷き詰めました。

 ` justify-content: space-evenly;`でいい感じに配置してみましたが、リーチアイコンが消えた時はcenterにしてマージンを設けた方が中央寄せで綺麗になるかもですがどちらがいいと思いますか。

pc画面にも対応させようとしたのですが、Icon,header,NavigationBarすべてに対応するのに疲れたのでいつか治したいな～って、、、、、、