### PR TITLE
NavigationBarの配置を正規のものにした＆リアクションモーダルの位置をnavbarの上に調整

### DIFF
--- a/view-user/src/components/Layout/Layout.tsx
+++ b/view-user/src/components/Layout/Layout.tsx
@@ -1,9 +1,12 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import {
   ReachIcon,
-  NavigationBar,
   PrizesIcon,
+  BackIcon,
+  ReactionsIcon,
+  SettingsIcon,
   ReactionStampModal,
+  NavigationBar,
   Header,
 } from "@/components/common";
 
@@ -18,18 +21,27 @@ const images = [
   { src: "/ReactionIcon/sad.png", alt: "sad icon" },
 ];
 
-const testPosition: string = "50%";
-
 interface LayoutProps {
   children: React.ReactNode;
   pageName: string;
 }
 
 const Layout = (props: LayoutProps) => {
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [isReachIconVisible, setReachIconVisible] = useState(true);
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [isReachIconVisible, setReachIconVisible] = useState<boolean>(true);
+  const [navBarHeight, setNavBarHeight] = useState<string>();
+  const navRef = useRef<HTMLDivElement>(null);
+  const position: string = isReachIconVisible ? "29%" : "50%";
 
-  // 初回レンダリング時に localStorage から状態を読み込む
+  // navBarの高さをstring型で渡す
+  useEffect(() => {
+    if (navRef.current) {
+      const height = navRef.current.getBoundingClientRect().height;
+      setNavBarHeight(height.toString());
+    }
+  }, []);
+
+  // localStorageから状態を読み込む
   useEffect(() => {
     const storedVisibility = localStorage.getItem("isReachIconVisible");
     if (storedVisibility !== null) {
@@ -46,35 +58,45 @@ const Layout = (props: LayoutProps) => {
     let icons = [];
     switch (pageName) {
       case "/":
-        // todoprizes,reactions,reach,settings
         icons = [
-          <PrizesIcon key="prize1" />,
-          <PrizesIcon key="prize2" />,
+          <PrizesIcon key="prize" />,
+          <ReactionsIcon
+            isOpen={isModalOpen}
+            setIsModalOpen={setIsModalOpen}
+            key="reaction"
+          />,
           isReachIconVisible && (
             <ReachIcon key="reach" onClick={handleReachIconClick} />
           ),
-          <PrizesIcon key="prize3" />,
+          <SettingsIcon key="settings" />,
         ];
         break;
       case "/prizes":
-        // todo back,reactions, reach,settings
         icons = [
-          <PrizesIcon key="prize1" />,
+          <BackIcon key="back" />,
+          <ReactionsIcon
+            isOpen={isModalOpen}
+            setIsModalOpen={setIsModalOpen}
+            key="reaction"
+          />,
           isReachIconVisible && (
             <ReachIcon key="reach" onClick={handleReachIconClick} />
           ),
-          <PrizesIcon key="prize2" />,
-          <PrizesIcon key="prize3" />,
+          <SettingsIcon key="settings" />,
         ];
         break;
       default:
         icons = [
-          <PrizesIcon key="prize1" />,
+          <PrizesIcon key="prize" />,
+          <ReactionsIcon
+            isOpen={isModalOpen}
+            setIsModalOpen={setIsModalOpen}
+            key="reaction"
+          />,
           isReachIconVisible && (
             <ReachIcon key="reach" onClick={handleReachIconClick} />
           ),
-          <PrizesIcon key="prize2" />,
-          <PrizesIcon key="prize3" />,
+          <SettingsIcon key="settings" />,
         ];
     }
     return icons.filter(Boolean);
@@ -84,12 +106,16 @@ const Layout = (props: LayoutProps) => {
 
   return (
     <div>
+      {isModalOpen && (
+        <ReactionStampModal
+          position={position}
+          height={navBarHeight}
+          images={images}
+        />
+      )}
       <Header />
       <main>{props.children}</main>
-      {isModalOpen && (
-        <ReactionStampModal position={testPosition} images={images} />
-      )}
-      <NavigationBar isCentered={iconElements.length <= 3}>
+      <NavigationBar ref={navRef} isCentered={iconElements.length <= 3}>
         {iconElements}
       </NavigationBar>
     </div>

--- a/view-user/src/components/common/NavigationBar/NavigationBar.tsx
+++ b/view-user/src/components/common/NavigationBar/NavigationBar.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { forwardRef } from "react";
 import classNames from "classnames";
 import styles from "./NavigationBar.module.css";
 
@@ -7,14 +7,20 @@ interface NavigationBarProps {
   isCentered: boolean;
 }
 
-const NavigationBar = ({ children, isCentered }: NavigationBarProps) => {
-  return (
-    <div className={classNames(styles.navigationBar, {
-      [styles.center]: isCentered,
-    })}>
-      {children}
-    </div>
-  );
-};
+const NavigationBar = forwardRef<HTMLDivElement, NavigationBarProps>(
+  ({ children, isCentered }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={classNames(styles.navigationBar, {
+          [styles.center]: isCentered,
+        })}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+NavigationBar.displayName = "NavigationBar";
 
 export default NavigationBar;

--- a/view-user/src/components/common/ReactionStampModal/ReactionStampModal.module.css
+++ b/view-user/src/components/common/ReactionStampModal/ReactionStampModal.module.css
@@ -1,15 +1,18 @@
+.horizontalCenter {
+  display: flex;
+  justify-content: center;
+}
+
 .bubble {
   width: 87.5vw;
   height: 50.9vw;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  position: relative;
+  position: absolute;
   background: #ffffff;
   box-shadow: 1.09375vw 1.09375vw 0px 0px #ff3341;
   border-radius: 5.46875vw;
   border: #ff3341 solid 1.640625vw;
   padding: 1rem;
+  z-index: 100;
 }
 
 .bubble:before {

--- a/view-user/src/components/common/ReactionStampModal/ReactionStampModal.tsx
+++ b/view-user/src/components/common/ReactionStampModal/ReactionStampModal.tsx
@@ -8,21 +8,34 @@ interface ImageProps {
 }
 interface ReactionStampModalProps {
   position?: string;
+  height?: string;
   images: ImageProps[];
 }
 
-const ReactionStampModal: React.FC<ReactionStampModalProps> = (props) => {
+const ReactionStampModal = (props: ReactionStampModalProps) => {
   const bubbleLeftPosition: React.CSSProperties = {
     "--bubble-left-position": props.position,
   } as React.CSSProperties;
+
+  const modalBottom: React.CSSProperties = {
+    bottom: props.height
+      ? `calc(${props.height}px + (${props.height}px / 7))`
+      : "0px",
+  };
+
   return (
-    <div className={styles.bubble} style={bubbleLeftPosition}>
-      <div className={styles.grid}>
-        {props.images.map((image, index) => (
-          <button key={index} className={styles.iconButton}>
-            <Image src={image.src} alt={image.alt} fill />
-          </button>
-        ))}
+    <div className={styles.horizontalCenter}>
+      <div
+        className={styles.bubble}
+        style={{ ...bubbleLeftPosition, ...modalBottom }}
+      >
+        <div className={styles.grid}>
+          {props.images.map((image, index) => (
+            <button key={index} className={styles.iconButton}>
+              <Image src={image.src} alt={image.alt} fill />
+            </button>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/view-user/src/pages/test/index.tsx
+++ b/view-user/src/pages/test/index.tsx
@@ -43,8 +43,8 @@ const HomePage: React.FC = () => {
       )} */}
       {/* <ReachIcon /> */}
       {/* <PrizeCardList BingoPrize={testBingoPrizes} /> */}
-      {/* <Layout pageName={pageName}>hello</Layout> */}
-      <ReachCount count={testNumber} />
+      <Layout pageName={pageName}>hello</Layout>
+      {/* <ReachCount count={testNumber} /> */}
     </div>
   );
 };


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #252

# 概要
<!-- 開発内容の概要を記載 -->
- NavigationBarの配置をfigmaのデザイン通りにした。
- リアクションモーダルの位置をnavbarの上にくるようにして、absolute属性を付与した。

# 実装詳細
<!-- 具体的な開発内容を記載 -->
gptが頑張りました。
まず、navigationBarの高さを取得するためにuseRefを用いました。
取得した高さをstring型でpropsで渡しbottomを設けました。
また、モーダルが他の要素とかぶせられるようにabsoluteに変更しました。
# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [ ] モーダルの位置がnavbarの上に来ているか。figmaを厳密に再現していません。
- [ ] 吹き出しの位置がreachIconの有無で変わるか
- [ ] layoutのchildrenを渡した時にモーダルが変な位置にいかないか
- [ ] あとは色々触ってデバッグしてください。

# 備考
<!-- 実装していて困った箇所・質問など -->
レンダリング時にnavbarの高さを取得するのであとからレスポンシブ幅を変更してもモーダルの位置は変わりません。
そのため、スマホを横画面にした際は画面が崩れます。