### PR TITLE
リーチカウントのAPIを作成【view-user】

### DIFF
--- a/api/metadata/databases/default/tables/public_reach_logs.yaml
+++ b/api/metadata/databases/default/tables/public_reach_logs.yaml
@@ -1,0 +1,3 @@
+table:
+  name: reach_logs
+  schema: public

--- a/api/metadata/databases/default/tables/tables.yaml
+++ b/api/metadata/databases/default/tables/tables.yaml
@@ -1,3 +1,4 @@
 - "!include public_images.yaml"
 - "!include public_numbers.yaml"
 - "!include public_prizes.yaml"
+- "!include public_reach_logs.yaml"

--- a/api/migrations/default/1720521696814_auto/up.sql
+++ b/api/migrations/default/1720521696814_auto/up.sql
@@ -65,14 +65,32 @@ CREATE SEQUENCE public.prizes_id_seq
     NO MAXVALUE
     CACHE 1;
 ALTER SEQUENCE public.prizes_id_seq OWNED BY public.prizes.id;
+CREATE TABLE public.reach_logs (
+    id integer NOT NULL,
+    status boolean DEFAULT false NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    reach_num integer DEFAULT 0 NOT NULL
+);
+COMMENT ON TABLE public.reach_logs IS 'リーチ数を記録するテーブル';
+CREATE SEQUENCE public.reach_log_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+ALTER SEQUENCE public.reach_log_id_seq OWNED BY public.reach_logs.id;
 ALTER TABLE ONLY public.images ALTER COLUMN id SET DEFAULT nextval('public.images_id_seq'::regclass);
 ALTER TABLE ONLY public.numbers ALTER COLUMN id SET DEFAULT nextval('public.numbers_id_seq'::regclass);
 ALTER TABLE ONLY public.prizes ALTER COLUMN id SET DEFAULT nextval('public.prizes_id_seq'::regclass);
+ALTER TABLE ONLY public.reach_logs ALTER COLUMN id SET DEFAULT nextval('public.reach_log_id_seq'::regclass);
 ALTER TABLE ONLY public.images
     ADD CONSTRAINT images_pkey PRIMARY KEY (id);
 ALTER TABLE ONLY public.numbers
     ADD CONSTRAINT numbers_pkey PRIMARY KEY (id);
 ALTER TABLE ONLY public.prizes
     ADD CONSTRAINT prizes_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.reach_logs
+    ADD CONSTRAINT reach_log_pkey PRIMARY KEY (id);
 ALTER TABLE ONLY public.prizes
     ADD CONSTRAINT prizes_image_id_fkey FOREIGN KEY (image_id) REFERENCES public.images(id) ON UPDATE RESTRICT ON DELETE RESTRICT;

--- a/view-user/src/components/Layout/Layout.tsx
+++ b/view-user/src/components/Layout/Layout.tsx
@@ -1,3 +1,13 @@
+import { useLazyQuery, useMutation } from "@apollo/client";
+import {
+  CreateOneReachRecordDocument,
+  GetOneLatestReachLogDocument,
+} from "@/type/graphql";
+import type {
+  CreateOneReachRecordMutationVariables,
+  CreateOneReachRecordMutation,
+  GetOneLatestReachLogQuery,
+} from "@/type/graphql";
 import { useState, useEffect, useRef, useLayoutEffect } from "react";
 import { useRouter } from "next/router";
 import styles from "./Layout.module.css";
@@ -50,6 +60,14 @@ const Layout = (props: LayoutProps) => {
   const navRef = useRef<HTMLDivElement>(null);
   const position: string = isReachIconVisible ? "29%" : "50%";
 
+  const [getLatestReachLog, { data: latestReachLogData }] =
+    useLazyQuery<GetOneLatestReachLogQuery>(GetOneLatestReachLogDocument);
+
+  const [createOneReachRecord] = useMutation<
+    CreateOneReachRecordMutation,
+    CreateOneReachRecordMutationVariables
+  >(CreateOneReachRecordDocument);
+
   // navBarの高さをstring型で渡す
   useLayoutEffect(() => {
     if (navRef.current) {
@@ -66,12 +84,24 @@ const Layout = (props: LayoutProps) => {
     }
   }, []);
 
-  const handleReachIconClick = () => {
-    // todo リーチカウントAPIと繋ぎ込み
+  const handleReachIconClick = async () => {
+    try {
+      const { data } = await getLatestReachLog();
+      const latestReachLogNumber = data?.reachLogs[0]?.reachNum || 0;
+      console.log(latestReachLogNumber);
+      await createOneReachRecord({
+        variables: {
+          status: true,
+          reachNum: latestReachLogNumber + 1,
+        },
+      });
 
-    setReachIconVisible(false);
-    localStorage.setItem("isReachIconVisible", "false");
-    setIsReachModalOpen(!isReachModalOpen);
+      setReachIconVisible(false);
+      localStorage.setItem("isReachIconVisible", "false");
+      setIsReachModalOpen(!isReachModalOpen);
+    } catch (error) {
+      console.error("Failed to record reach:", error);
+    }
   };
 
   const toggleSortOrder = () => {

--- a/view-user/src/components/Layout/Layout.tsx
+++ b/view-user/src/components/Layout/Layout.tsx
@@ -88,7 +88,6 @@ const Layout = (props: LayoutProps) => {
     try {
       const { data } = await getLatestReachLog();
       const latestReachLogNumber = data?.reachLogs[0]?.reachNum || 0;
-      console.log(latestReachLogNumber);
       await createOneReachRecord({
         variables: {
           status: true,

--- a/view-user/src/gql/reach_logs.gql
+++ b/view-user/src/gql/reach_logs.gql
@@ -1,0 +1,31 @@
+# リーチログの最新のreachNumを取得(Get)
+query GetOneLatestReachLog {
+  reachLogs(orderBy: { createdAt: DESC }, limit: 1) {
+    reachNum
+  }
+}
+
+# 指定したタイプスタンプ以降のリーチログを全て取得(Get)
+query GetListReachLogsAfterTimestamp($timestamp: timestamptz!) {
+  reachLogs(
+    where: { createdAt: { _gt: $timestamp } }
+    orderBy: { createdAt: ASC }
+  ) {
+    id
+    status
+    createdAt
+    reachNum
+  }
+}
+
+# リーチログの追加(Create)
+mutation CreateOneReachRecord($status: Boolean!, $reachNum: Int!) {
+  insertReachLogsOne(
+    object: { status: $status, reachNum: $reachNum, createdAt: "now()" }
+  ) {
+    id
+    status
+    createdAt
+    reachNum
+  }
+}

--- a/view-user/src/type/graphql.ts
+++ b/view-user/src/type/graphql.ts
@@ -874,6 +874,233 @@ export type PrizesVarianceFields = {
   imageId?: Maybe<Scalars["Float"]["output"]>;
 };
 
+/** リーチ数を記録するテーブル */
+export type ReachLogs = {
+  __typename?: "ReachLogs";
+  createdAt: Scalars["timestamptz"]["output"];
+  id: Scalars["Int"]["output"];
+  reachNum: Scalars["Int"]["output"];
+  status: Scalars["Boolean"]["output"];
+};
+
+/** aggregated selection of "reach_logs" */
+export type ReachLogsAggregate = {
+  __typename?: "ReachLogsAggregate";
+  aggregate?: Maybe<ReachLogsAggregateFields>;
+  nodes: Array<ReachLogs>;
+};
+
+/** aggregate fields of "reach_logs" */
+export type ReachLogsAggregateFields = {
+  __typename?: "ReachLogsAggregateFields";
+  avg?: Maybe<ReachLogsAvgFields>;
+  count: Scalars["Int"]["output"];
+  max?: Maybe<ReachLogsMaxFields>;
+  min?: Maybe<ReachLogsMinFields>;
+  stddev?: Maybe<ReachLogsStddevFields>;
+  stddevPop?: Maybe<ReachLogsStddevPopFields>;
+  stddevSamp?: Maybe<ReachLogsStddevSampFields>;
+  sum?: Maybe<ReachLogsSumFields>;
+  varPop?: Maybe<ReachLogsVarPopFields>;
+  varSamp?: Maybe<ReachLogsVarSampFields>;
+  variance?: Maybe<ReachLogsVarianceFields>;
+};
+
+/** aggregate fields of "reach_logs" */
+export type ReachLogsAggregateFieldsCountArgs = {
+  columns?: InputMaybe<Array<ReachLogsSelectColumn>>;
+  distinct?: InputMaybe<Scalars["Boolean"]["input"]>;
+};
+
+/** aggregate avg on columns */
+export type ReachLogsAvgFields = {
+  __typename?: "ReachLogsAvgFields";
+  id?: Maybe<Scalars["Float"]["output"]>;
+  reachNum?: Maybe<Scalars["Float"]["output"]>;
+};
+
+/** Boolean expression to filter rows from the table "reach_logs". All fields are combined with a logical 'AND'. */
+export type ReachLogsBoolExp = {
+  _and?: InputMaybe<Array<ReachLogsBoolExp>>;
+  _not?: InputMaybe<ReachLogsBoolExp>;
+  _or?: InputMaybe<Array<ReachLogsBoolExp>>;
+  createdAt?: InputMaybe<TimestamptzComparisonExp>;
+  id?: InputMaybe<IntComparisonExp>;
+  reachNum?: InputMaybe<IntComparisonExp>;
+  status?: InputMaybe<BooleanComparisonExp>;
+};
+
+/** unique or primary key constraints on table "reach_logs" */
+export enum ReachLogsConstraint {
+  /** unique or primary key constraint on columns "id" */
+  reachLogPkey = "reach_log_pkey",
+}
+
+/** input type for incrementing numeric columns in table "reach_logs" */
+export type ReachLogsIncInput = {
+  id?: InputMaybe<Scalars["Int"]["input"]>;
+  reachNum?: InputMaybe<Scalars["Int"]["input"]>;
+};
+
+/** input type for inserting data into table "reach_logs" */
+export type ReachLogsInsertInput = {
+  createdAt?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  id?: InputMaybe<Scalars["Int"]["input"]>;
+  reachNum?: InputMaybe<Scalars["Int"]["input"]>;
+  status?: InputMaybe<Scalars["Boolean"]["input"]>;
+};
+
+/** aggregate max on columns */
+export type ReachLogsMaxFields = {
+  __typename?: "ReachLogsMaxFields";
+  createdAt?: Maybe<Scalars["timestamptz"]["output"]>;
+  id?: Maybe<Scalars["Int"]["output"]>;
+  reachNum?: Maybe<Scalars["Int"]["output"]>;
+};
+
+/** aggregate min on columns */
+export type ReachLogsMinFields = {
+  __typename?: "ReachLogsMinFields";
+  createdAt?: Maybe<Scalars["timestamptz"]["output"]>;
+  id?: Maybe<Scalars["Int"]["output"]>;
+  reachNum?: Maybe<Scalars["Int"]["output"]>;
+};
+
+/** response of any mutation on the table "reach_logs" */
+export type ReachLogsMutationResponse = {
+  __typename?: "ReachLogsMutationResponse";
+  /** number of rows affected by the mutation */
+  affectedRows: Scalars["Int"]["output"];
+  /** data from the rows affected by the mutation */
+  returning: Array<ReachLogs>;
+};
+
+/** on_conflict condition type for table "reach_logs" */
+export type ReachLogsOnConflict = {
+  constraint: ReachLogsConstraint;
+  updateColumns?: Array<ReachLogsUpdateColumn>;
+  where?: InputMaybe<ReachLogsBoolExp>;
+};
+
+/** Ordering options when selecting data from "reach_logs". */
+export type ReachLogsOrderBy = {
+  createdAt?: InputMaybe<OrderBy>;
+  id?: InputMaybe<OrderBy>;
+  reachNum?: InputMaybe<OrderBy>;
+  status?: InputMaybe<OrderBy>;
+};
+
+/** primary key columns input for table: reach_logs */
+export type ReachLogsPkColumnsInput = {
+  id: Scalars["Int"]["input"];
+};
+
+/** select columns of table "reach_logs" */
+export enum ReachLogsSelectColumn {
+  /** column name */
+  createdAt = "createdAt",
+  /** column name */
+  id = "id",
+  /** column name */
+  reachNum = "reachNum",
+  /** column name */
+  status = "status",
+}
+
+/** input type for updating data in table "reach_logs" */
+export type ReachLogsSetInput = {
+  createdAt?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  id?: InputMaybe<Scalars["Int"]["input"]>;
+  reachNum?: InputMaybe<Scalars["Int"]["input"]>;
+  status?: InputMaybe<Scalars["Boolean"]["input"]>;
+};
+
+/** aggregate stddev on columns */
+export type ReachLogsStddevFields = {
+  __typename?: "ReachLogsStddevFields";
+  id?: Maybe<Scalars["Float"]["output"]>;
+  reachNum?: Maybe<Scalars["Float"]["output"]>;
+};
+
+/** aggregate stddevPop on columns */
+export type ReachLogsStddevPopFields = {
+  __typename?: "ReachLogsStddevPopFields";
+  id?: Maybe<Scalars["Float"]["output"]>;
+  reachNum?: Maybe<Scalars["Float"]["output"]>;
+};
+
+/** aggregate stddevSamp on columns */
+export type ReachLogsStddevSampFields = {
+  __typename?: "ReachLogsStddevSampFields";
+  id?: Maybe<Scalars["Float"]["output"]>;
+  reachNum?: Maybe<Scalars["Float"]["output"]>;
+};
+
+/** Streaming cursor of the table "reach_logs" */
+export type ReachLogsStreamCursorInput = {
+  /** Stream column input with initial value */
+  initialValue: ReachLogsStreamCursorValueInput;
+  /** cursor ordering */
+  ordering?: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type ReachLogsStreamCursorValueInput = {
+  createdAt?: InputMaybe<Scalars["timestamptz"]["input"]>;
+  id?: InputMaybe<Scalars["Int"]["input"]>;
+  reachNum?: InputMaybe<Scalars["Int"]["input"]>;
+  status?: InputMaybe<Scalars["Boolean"]["input"]>;
+};
+
+/** aggregate sum on columns */
+export type ReachLogsSumFields = {
+  __typename?: "ReachLogsSumFields";
+  id?: Maybe<Scalars["Int"]["output"]>;
+  reachNum?: Maybe<Scalars["Int"]["output"]>;
+};
+
+/** update columns of table "reach_logs" */
+export enum ReachLogsUpdateColumn {
+  /** column name */
+  createdAt = "createdAt",
+  /** column name */
+  id = "id",
+  /** column name */
+  reachNum = "reachNum",
+  /** column name */
+  status = "status",
+}
+
+export type ReachLogsUpdates = {
+  /** increments the numeric columns with given value of the filtered values */
+  _inc?: InputMaybe<ReachLogsIncInput>;
+  /** sets the columns of the filtered rows to the given values */
+  _set?: InputMaybe<ReachLogsSetInput>;
+  /** filter the rows which have to be updated */
+  where: ReachLogsBoolExp;
+};
+
+/** aggregate varPop on columns */
+export type ReachLogsVarPopFields = {
+  __typename?: "ReachLogsVarPopFields";
+  id?: Maybe<Scalars["Float"]["output"]>;
+  reachNum?: Maybe<Scalars["Float"]["output"]>;
+};
+
+/** aggregate varSamp on columns */
+export type ReachLogsVarSampFields = {
+  __typename?: "ReachLogsVarSampFields";
+  id?: Maybe<Scalars["Float"]["output"]>;
+  reachNum?: Maybe<Scalars["Float"]["output"]>;
+};
+
+/** aggregate variance on columns */
+export type ReachLogsVarianceFields = {
+  __typename?: "ReachLogsVarianceFields";
+  id?: Maybe<Scalars["Float"]["output"]>;
+  reachNum?: Maybe<Scalars["Float"]["output"]>;
+};
+
 /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
 export type StringComparisonExp = {
   _eq?: InputMaybe<Scalars["String"]["input"]>;
@@ -935,6 +1162,10 @@ export type MutationRoot = {
   deletePrizes?: Maybe<PrizesMutationResponse>;
   /** delete single row from the table: "prizes" */
   deletePrizesByPk?: Maybe<Prizes>;
+  /** delete data from the table: "reach_logs" */
+  deleteReachLogs?: Maybe<ReachLogsMutationResponse>;
+  /** delete single row from the table: "reach_logs" */
+  deleteReachLogsByPk?: Maybe<ReachLogs>;
   /** insert data into the table: "images" */
   insertImages?: Maybe<ImagesMutationResponse>;
   /** insert a single row into the table: "images" */
@@ -947,6 +1178,10 @@ export type MutationRoot = {
   insertPrizes?: Maybe<PrizesMutationResponse>;
   /** insert a single row into the table: "prizes" */
   insertPrizesOne?: Maybe<Prizes>;
+  /** insert data into the table: "reach_logs" */
+  insertReachLogs?: Maybe<ReachLogsMutationResponse>;
+  /** insert a single row into the table: "reach_logs" */
+  insertReachLogsOne?: Maybe<ReachLogs>;
   /** update data of the table: "images" */
   updateImages?: Maybe<ImagesMutationResponse>;
   /** update single row of the table: "images" */
@@ -965,6 +1200,12 @@ export type MutationRoot = {
   updatePrizesByPk?: Maybe<Prizes>;
   /** update multiples rows of table: "prizes" */
   updatePrizesMany?: Maybe<Array<Maybe<PrizesMutationResponse>>>;
+  /** update data of the table: "reach_logs" */
+  updateReachLogs?: Maybe<ReachLogsMutationResponse>;
+  /** update single row of the table: "reach_logs" */
+  updateReachLogsByPk?: Maybe<ReachLogs>;
+  /** update multiples rows of table: "reach_logs" */
+  updateReachLogsMany?: Maybe<Array<Maybe<ReachLogsMutationResponse>>>;
 };
 
 /** mutation root */
@@ -994,6 +1235,16 @@ export type MutationRootDeletePrizesArgs = {
 
 /** mutation root */
 export type MutationRootDeletePrizesByPkArgs = {
+  id: Scalars["Int"]["input"];
+};
+
+/** mutation root */
+export type MutationRootDeleteReachLogsArgs = {
+  where: ReachLogsBoolExp;
+};
+
+/** mutation root */
+export type MutationRootDeleteReachLogsByPkArgs = {
   id: Scalars["Int"]["input"];
 };
 
@@ -1031,6 +1282,18 @@ export type MutationRootInsertPrizesArgs = {
 export type MutationRootInsertPrizesOneArgs = {
   object: PrizesInsertInput;
   onConflict?: InputMaybe<PrizesOnConflict>;
+};
+
+/** mutation root */
+export type MutationRootInsertReachLogsArgs = {
+  objects: Array<ReachLogsInsertInput>;
+  onConflict?: InputMaybe<ReachLogsOnConflict>;
+};
+
+/** mutation root */
+export type MutationRootInsertReachLogsOneArgs = {
+  object: ReachLogsInsertInput;
+  onConflict?: InputMaybe<ReachLogsOnConflict>;
 };
 
 /** mutation root */
@@ -1090,6 +1353,25 @@ export type MutationRootUpdatePrizesManyArgs = {
   updates: Array<PrizesUpdates>;
 };
 
+/** mutation root */
+export type MutationRootUpdateReachLogsArgs = {
+  _inc?: InputMaybe<ReachLogsIncInput>;
+  _set?: InputMaybe<ReachLogsSetInput>;
+  where: ReachLogsBoolExp;
+};
+
+/** mutation root */
+export type MutationRootUpdateReachLogsByPkArgs = {
+  _inc?: InputMaybe<ReachLogsIncInput>;
+  _set?: InputMaybe<ReachLogsSetInput>;
+  pkColumns: ReachLogsPkColumnsInput;
+};
+
+/** mutation root */
+export type MutationRootUpdateReachLogsManyArgs = {
+  updates: Array<ReachLogsUpdates>;
+};
+
 export type QueryRoot = {
   __typename?: "query_root";
   /** fetch data from the table: "images" */
@@ -1110,6 +1392,12 @@ export type QueryRoot = {
   prizesAggregate: PrizesAggregate;
   /** fetch data from the table: "prizes" using primary key columns */
   prizesByPk?: Maybe<Prizes>;
+  /** fetch data from the table: "reach_logs" */
+  reachLogs: Array<ReachLogs>;
+  /** fetch aggregated fields from the table: "reach_logs" */
+  reachLogsAggregate: ReachLogsAggregate;
+  /** fetch data from the table: "reach_logs" using primary key columns */
+  reachLogsByPk?: Maybe<ReachLogs>;
 };
 
 export type QueryRootImagesArgs = {
@@ -1172,6 +1460,26 @@ export type QueryRootPrizesByPkArgs = {
   id: Scalars["Int"]["input"];
 };
 
+export type QueryRootReachLogsArgs = {
+  distinctOn?: InputMaybe<Array<ReachLogsSelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<Array<ReachLogsOrderBy>>;
+  where?: InputMaybe<ReachLogsBoolExp>;
+};
+
+export type QueryRootReachLogsAggregateArgs = {
+  distinctOn?: InputMaybe<Array<ReachLogsSelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<Array<ReachLogsOrderBy>>;
+  where?: InputMaybe<ReachLogsBoolExp>;
+};
+
+export type QueryRootReachLogsByPkArgs = {
+  id: Scalars["Int"]["input"];
+};
+
 export type SubscriptionRoot = {
   __typename?: "subscription_root";
   /** fetch data from the table: "images" */
@@ -1198,6 +1506,14 @@ export type SubscriptionRoot = {
   prizesByPk?: Maybe<Prizes>;
   /** fetch data from the table in a streaming manner: "prizes" */
   prizesStream: Array<Prizes>;
+  /** fetch data from the table: "reach_logs" */
+  reachLogs: Array<ReachLogs>;
+  /** fetch aggregated fields from the table: "reach_logs" */
+  reachLogsAggregate: ReachLogsAggregate;
+  /** fetch data from the table: "reach_logs" using primary key columns */
+  reachLogsByPk?: Maybe<ReachLogs>;
+  /** fetch data from the table in a streaming manner: "reach_logs" */
+  reachLogsStream: Array<ReachLogs>;
 };
 
 export type SubscriptionRootImagesArgs = {
@@ -1276,6 +1592,32 @@ export type SubscriptionRootPrizesStreamArgs = {
   batchSize: Scalars["Int"]["input"];
   cursor: Array<InputMaybe<PrizesStreamCursorInput>>;
   where?: InputMaybe<PrizesBoolExp>;
+};
+
+export type SubscriptionRootReachLogsArgs = {
+  distinctOn?: InputMaybe<Array<ReachLogsSelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<Array<ReachLogsOrderBy>>;
+  where?: InputMaybe<ReachLogsBoolExp>;
+};
+
+export type SubscriptionRootReachLogsAggregateArgs = {
+  distinctOn?: InputMaybe<Array<ReachLogsSelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<Array<ReachLogsOrderBy>>;
+  where?: InputMaybe<ReachLogsBoolExp>;
+};
+
+export type SubscriptionRootReachLogsByPkArgs = {
+  id: Scalars["Int"]["input"];
+};
+
+export type SubscriptionRootReachLogsStreamArgs = {
+  batchSize: Scalars["Int"]["input"];
+  cursor: Array<InputMaybe<ReachLogsStreamCursorInput>>;
+  where?: InputMaybe<ReachLogsBoolExp>;
 };
 
 export type CreateOneImageMutationVariables = Exact<{
@@ -1461,6 +1803,46 @@ export type UpdateOnePrizeIsWonMutation = {
     __typename?: "Prizes";
     id: number;
     isWon: boolean;
+  } | null;
+};
+
+export type GetOneLatestReachLogQueryVariables = Exact<{
+  [key: string]: never;
+}>;
+
+export type GetOneLatestReachLogQuery = {
+  __typename?: "query_root";
+  reachLogs: Array<{ __typename?: "ReachLogs"; reachNum: number }>;
+};
+
+export type GetListReachLogsAfterTimestampQueryVariables = Exact<{
+  timestamp: Scalars["timestamptz"]["input"];
+}>;
+
+export type GetListReachLogsAfterTimestampQuery = {
+  __typename?: "query_root";
+  reachLogs: Array<{
+    __typename?: "ReachLogs";
+    id: number;
+    status: boolean;
+    createdAt: any;
+    reachNum: number;
+  }>;
+};
+
+export type CreateOneReachRecordMutationVariables = Exact<{
+  status: Scalars["Boolean"]["input"];
+  reachNum: Scalars["Int"]["input"];
+}>;
+
+export type CreateOneReachRecordMutation = {
+  __typename?: "mutation_root";
+  insertReachLogsOne?: {
+    __typename?: "ReachLogs";
+    id: number;
+    status: boolean;
+    createdAt: any;
+    reachNum: number;
   } | null;
 };
 
@@ -1724,4 +2106,54 @@ export type UpdateOnePrizeIsWonMutationResult =
 export type UpdateOnePrizeIsWonMutationOptions = Apollo.BaseMutationOptions<
   UpdateOnePrizeIsWonMutation,
   UpdateOnePrizeIsWonMutationVariables
+>;
+export const GetOneLatestReachLogDocument = gql`
+  query GetOneLatestReachLog {
+    reachLogs(orderBy: { createdAt: DESC }, limit: 1) {
+      reachNum
+    }
+  }
+`;
+export type GetOneLatestReachLogQueryResult = Apollo.QueryResult<
+  GetOneLatestReachLogQuery,
+  GetOneLatestReachLogQueryVariables
+>;
+export const GetListReachLogsAfterTimestampDocument = gql`
+  query GetListReachLogsAfterTimestamp($timestamp: timestamptz!) {
+    reachLogs(
+      where: { createdAt: { _gt: $timestamp } }
+      orderBy: { createdAt: ASC }
+    ) {
+      id
+      status
+      createdAt
+      reachNum
+    }
+  }
+`;
+export type GetListReachLogsAfterTimestampQueryResult = Apollo.QueryResult<
+  GetListReachLogsAfterTimestampQuery,
+  GetListReachLogsAfterTimestampQueryVariables
+>;
+export const CreateOneReachRecordDocument = gql`
+  mutation CreateOneReachRecord($status: Boolean!, $reachNum: Int!) {
+    insertReachLogsOne(
+      object: { status: $status, reachNum: $reachNum, createdAt: "now()" }
+    ) {
+      id
+      status
+      createdAt
+      reachNum
+    }
+  }
+`;
+export type CreateOneReachRecordMutationFn = Apollo.MutationFunction<
+  CreateOneReachRecordMutation,
+  CreateOneReachRecordMutationVariables
+>;
+export type CreateOneReachRecordMutationResult =
+  Apollo.MutationResult<CreateOneReachRecordMutation>;
+export type CreateOneReachRecordMutationOptions = Apollo.BaseMutationOptions<
+  CreateOneReachRecordMutation,
+  CreateOneReachRecordMutationVariables
 >;


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
- resolve #267 

# 概要
<!-- 開発内容の概要を記載 -->
リーチカウントのAPIを作成 user側

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- reach_logsテーブルを作成
  - id
  - status: trueの時にリーチ数増加，falseの時reach数減少
  - created_at: 追加した時間
  - reachNum: 現在のリーチ数
- graphqlクエリ，ミューテーションを作成
- components/layoutのhandleReachIconClick関数の中の処理を変更
  - `GetOneLatestReachLog`のクエリで，最新のリーチ数の時間を取得
  - `CreateOneReachRecord`のミューテーションで，新規レコードを追加

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [ ] リーチボタンを押した時に，hasura consoleで，reachNumの値が1つ前のレコードより増加していることを確認
- [ ] 
- [ ] 

# 備考
<!-- 実装していて困った箇所・質問など -->
