### PR TITLE
リーチ数をスクリーンに表示する

### DIFF
--- a/view-admin/src/gql/reach_log.gql
+++ b/view-admin/src/gql/reach_log.gql
@@ -1,0 +1,38 @@
+# リーチログの最新のreachNumを取得(Get)
+query GetOneLatestReachLog {
+  reachLogs(orderBy: { createdAt: DESC }, limit: 1) {
+    reachNum
+  }
+}
+
+# リーチログの最新のreachNumを継続取得(Subscription)
+subscription SubscribeOneLatestReachlog {
+  reachLogs(orderBy: { createdAt: DESC }, limit: 1) {
+    reachNum
+  }
+}
+
+# 指定したタイプスタンプ以降のリーチログを全て取得(Get)
+query GetListReachLogsAfterTimestamp($timestamp: timestamptz!) {
+  reachLogs(
+    where: { createdAt: { _gt: $timestamp } }
+    orderBy: { createdAt: ASC }
+  ) {
+    id
+    status
+    createdAt
+    reachNum
+  }
+}
+
+# リーチログの追加(Create)
+mutation CreateOneReachRecord($status: Boolean!, $reachNum: Int!) {
+  insertReachLogsOne(
+    object: { status: $status, reachNum: $reachNum, createdAt: "now()" }
+  ) {
+    id
+    status
+    createdAt
+    reachNum
+  }
+}

--- a/view-admin/src/type/graphql.ts
+++ b/view-admin/src/type/graphql.ts
@@ -2141,6 +2141,55 @@ export type UpdateOnePrizeIsWonMutation = {
   } | null;
 };
 
+export type GetOneLatestReachLogQueryVariables = Exact<{
+  [key: string]: never;
+}>;
+
+export type GetOneLatestReachLogQuery = {
+  __typename?: "query_root";
+  reachLogs: Array<{ __typename?: "ReachLogs"; reachNum: number }>;
+};
+
+export type SubscribeOneLatestReachlogSubscriptionVariables = Exact<{
+  [key: string]: never;
+}>;
+
+export type SubscribeOneLatestReachlogSubscription = {
+  __typename?: "subscription_root";
+  reachLogs: Array<{ __typename?: "ReachLogs"; reachNum: number }>;
+};
+
+export type GetListReachLogsAfterTimestampQueryVariables = Exact<{
+  timestamp: Scalars["timestamptz"]["input"];
+}>;
+
+export type GetListReachLogsAfterTimestampQuery = {
+  __typename?: "query_root";
+  reachLogs: Array<{
+    __typename?: "ReachLogs";
+    id: number;
+    status: boolean;
+    createdAt: any;
+    reachNum: number;
+  }>;
+};
+
+export type CreateOneReachRecordMutationVariables = Exact<{
+  status: Scalars["Boolean"]["input"];
+  reachNum: Scalars["Int"]["input"];
+}>;
+
+export type CreateOneReachRecordMutation = {
+  __typename?: "mutation_root";
+  insertReachLogsOne?: {
+    __typename?: "ReachLogs";
+    id: number;
+    status: boolean;
+    createdAt: any;
+    reachNum: number;
+  } | null;
+};
+
 export const CreateOneImageDocument = gql`
   mutation CreateOneImage(
     $bucketName: String!
@@ -2401,4 +2450,63 @@ export type UpdateOnePrizeIsWonMutationResult =
 export type UpdateOnePrizeIsWonMutationOptions = Apollo.BaseMutationOptions<
   UpdateOnePrizeIsWonMutation,
   UpdateOnePrizeIsWonMutationVariables
+>;
+export const GetOneLatestReachLogDocument = gql`
+  query GetOneLatestReachLog {
+    reachLogs(orderBy: { createdAt: DESC }, limit: 1) {
+      reachNum
+    }
+  }
+`;
+export type GetOneLatestReachLogQueryResult = Apollo.QueryResult<
+  GetOneLatestReachLogQuery,
+  GetOneLatestReachLogQueryVariables
+>;
+export const SubscribeOneLatestReachlogDocument = gql`
+  subscription SubscribeOneLatestReachlog {
+    reachLogs(orderBy: { createdAt: DESC }, limit: 1) {
+      reachNum
+    }
+  }
+`;
+export type SubscribeOneLatestReachlogSubscriptionResult =
+  Apollo.SubscriptionResult<SubscribeOneLatestReachlogSubscription>;
+export const GetListReachLogsAfterTimestampDocument = gql`
+  query GetListReachLogsAfterTimestamp($timestamp: timestamptz!) {
+    reachLogs(
+      where: { createdAt: { _gt: $timestamp } }
+      orderBy: { createdAt: ASC }
+    ) {
+      id
+      status
+      createdAt
+      reachNum
+    }
+  }
+`;
+export type GetListReachLogsAfterTimestampQueryResult = Apollo.QueryResult<
+  GetListReachLogsAfterTimestampQuery,
+  GetListReachLogsAfterTimestampQueryVariables
+>;
+export const CreateOneReachRecordDocument = gql`
+  mutation CreateOneReachRecord($status: Boolean!, $reachNum: Int!) {
+    insertReachLogsOne(
+      object: { status: $status, reachNum: $reachNum, createdAt: "now()" }
+    ) {
+      id
+      status
+      createdAt
+      reachNum
+    }
+  }
+`;
+export type CreateOneReachRecordMutationFn = Apollo.MutationFunction<
+  CreateOneReachRecordMutation,
+  CreateOneReachRecordMutationVariables
+>;
+export type CreateOneReachRecordMutationResult =
+  Apollo.MutationResult<CreateOneReachRecordMutation>;
+export type CreateOneReachRecordMutationOptions = Apollo.BaseMutationOptions<
+  CreateOneReachRecordMutation,
+  CreateOneReachRecordMutationVariables
 >;

--- a/view-user/src/gql/reach_logs.gql
+++ b/view-user/src/gql/reach_logs.gql
@@ -5,6 +5,13 @@ query GetOneLatestReachLog {
   }
 }
 
+# リーチログの最新のreachNumを継続取得(Subscription)
+subscription SubscribeOneLatestReachlog {
+  reachLogs(orderBy: { createdAt: DESC }, limit: 1) {
+    reachNum
+  }
+}
+
 # 指定したタイプスタンプ以降のリーチログを全て取得(Get)
 query GetListReachLogsAfterTimestamp($timestamp: timestamptz!) {
   reachLogs(

--- a/view-user/src/pages/screen/index.tsx
+++ b/view-user/src/pages/screen/index.tsx
@@ -210,7 +210,7 @@ const Page: NextPage = () => {
           <div className={styles.column}>
             <NumberCardList screen bingoNumber={displayBingoNumbers.list} />
             {/* // TODO オプショナルでエラーを逃れているのを対処する */}
-            <ReachCount count={reachLog?.reachLogs[0].reachNum || 0} />
+            <ReachCount count={reachLog?.reachLogs[0]?.reachNum || 0} />
           </div>
         </div>
       </div>

--- a/view-user/src/pages/screen/index.tsx
+++ b/view-user/src/pages/screen/index.tsx
@@ -6,10 +6,12 @@ import { useSubscription } from "@apollo/client";
 import {
   SubscribeListNumbersDocument,
   SubscribeUpdatedStampTriggerDocument,
+  SubscribeOneLatestReachlogDocument,
 } from "@/type/graphql";
 import type {
   SubscribeListNumbersSubscription,
   SubscribeUpdatedStampTriggerSubscription,
+  SubscribeOneLatestReachlogSubscription,
 } from "@/type/graphql";
 import {
   NumberCardLarge,
@@ -70,6 +72,10 @@ const Page: NextPage = () => {
       {
         variables: { updatedAt: lastUpdatedAt },
       },
+    );
+  const { data: reachLog } =
+    useSubscription<SubscribeOneLatestReachlogSubscription>(
+      SubscribeOneLatestReachlogDocument,
     );
 
   // スタンプの変更を検知し、スタンプを降下させる。
@@ -203,8 +209,8 @@ const Page: NextPage = () => {
           <NumberCardLarge bingoNumber={displayBingoNumbers.large} />
           <div className={styles.column}>
             <NumberCardList screen bingoNumber={displayBingoNumbers.list} />
-            {/* todo countはAPIとつなぎ込み */}
-            <ReachCount count={0} />
+            {/* // TODO オプショナルでエラーを逃れているのを対処する */}
+            <ReachCount count={reachLog?.reachLogs[0].reachNum || 0} />
           </div>
         </div>
       </div>

--- a/view-user/src/type/graphql.ts
+++ b/view-user/src/type/graphql.ts
@@ -2150,6 +2150,15 @@ export type GetOneLatestReachLogQuery = {
   reachLogs: Array<{ __typename?: "ReachLogs"; reachNum: number }>;
 };
 
+export type SubscribeOneLatestReachlogSubscriptionVariables = Exact<{
+  [key: string]: never;
+}>;
+
+export type SubscribeOneLatestReachlogSubscription = {
+  __typename?: "subscription_root";
+  reachLogs: Array<{ __typename?: "ReachLogs"; reachNum: number }>;
+};
+
 export type GetListReachLogsAfterTimestampQueryVariables = Exact<{
   timestamp: Scalars["timestamptz"]["input"];
 }>;
@@ -2533,6 +2542,15 @@ export type GetOneLatestReachLogQueryResult = Apollo.QueryResult<
   GetOneLatestReachLogQuery,
   GetOneLatestReachLogQueryVariables
 >;
+export const SubscribeOneLatestReachlogDocument = gql`
+  subscription SubscribeOneLatestReachlog {
+    reachLogs(orderBy: { createdAt: DESC }, limit: 1) {
+      reachNum
+    }
+  }
+`;
+export type SubscribeOneLatestReachlogSubscriptionResult =
+  Apollo.SubscriptionResult<SubscribeOneLatestReachlogSubscription>;
 export const GetListReachLogsAfterTimestampDocument = gql`
   query GetListReachLogsAfterTimestamp($timestamp: timestamptz!) {
     reachLogs(


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->

# 対応Issue

<!-- 対応したIssue番号を記載 -->

- resolve #287 

# 概要

<!-- 開発内容の概要を記載 -->
# 実装詳細
- userのスクリーンページに現在のリーチ数をリアルタイムで表示機能を追加
- adminで，リーチ数の増減機能を追加

<!-- 具体的な開発内容を記載 -->
- reach_logs テーブルのreachNumをsubscriptionで取得して表示する
- adminで，リーチ数の最新の値をlazyQueryで取得して，+1 or -1することで増減をする

# 画面スクリーンショット等

<!-- URLとともに貼る（なければ空欄でよい） -->

# テスト項目

<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->

- [ ] スクリーンページに最新のリーチ数が表示されるか確認する
- [ ] adminで，リーチ数が増減できる確認する
- [ ]

# 備考

<!-- 実装していて困った箇所・質問など -->
