### PR TITLE
同時接続数測定スクリプトの作成

### DIFF
--- a/monitor_connections.sh
+++ b/monitor_connections.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+connection_count=0
+max_connection_count=0
+
+sudo docker compose -f docker-compose.prod.yml logs -f api | while read -r line
+do
+  if echo "$line" | grep -q "accepted"; then
+    ((connection_count++))
+    if (( connection_count > max_connection_count )); then
+      max_connection_count=$connection_count
+    fi
+  elif echo "$line" | grep -q "\"type\":\"closed\""; then
+    ((connection_count--))
+  fi
+  echo -ne "現在の同時接続数: $((connection_count / 2)), 最大同時接続数: $((max_connection_count / 2))\r"
+done

--- a/monitor_connections.sh
+++ b/monitor_connections.sh
@@ -1,17 +1,29 @@
 #!/bin/bash
 
-connection_count=0
-max_connection_count=0
+current_connections=0
+max_connections=0
 
-sudo docker compose -f docker-compose.prod.yml logs -f api 2>/dev/null | while read -r line
-do
-  if echo "$line" | grep -q "accepted"; then
-    ((connection_count++))
-    if (( connection_count > max_connection_count )); then
-      max_connection_count=$connection_count
+HEADER_COLOR='\033[38;5;196m'
+DATA_COLOR='\033[38;5;222m'
+RESET_COLOR='\033[0m'
+
+sudo docker compose -f docker-compose.prod.yml logs -f api 2>/dev/null | while read -r line; do
+  if [[ "$line" == *"accepted"* ]]; then
+    ((current_connections++))
+    if ((current_connections > max_connections)); then
+      max_connections=$current_connections
     fi
-  elif echo "$line" | grep -q "closed"; then
-    ((connection_count--))
+  elif [[ "$line" == *"closed"* ]]; then
+    ((current_connections--))
   fi
-  echo -ne "現在の同時接続数: $connection_count, 最大同時接続数: $max_connection_count\r"
+
+  if [[ "$current_connections" != "$prevConnections" ]]; then
+    clear
+    prevConnections="$current_connections"
+
+    echo -e "${HEADER_COLOR}BINGO CONNECTION MONITOR${RESET_COLOR}\n"
+    echo -e "同時接続数: ${DATA_COLOR}$current_connections${RESET_COLOR}\n"
+    echo -e "最大同時接続数: ${DATA_COLOR}$max_connections${RESET_COLOR}\n"
+    echo -e "タイムスタンプ: ${DATA_COLOR}$(date +"%Y-%m-%d %H:%M:%S")${RESET_COLOR}\n"
+  fi
 done

--- a/monitor_connections.sh
+++ b/monitor_connections.sh
@@ -7,7 +7,9 @@ HEADER_COLOR='\033[38;5;196m'
 DATA_COLOR='\033[38;5;222m'
 RESET_COLOR='\033[0m'
 
-sudo docker compose -f docker-compose.prod.yml logs -f api 2>/dev/null | while read -r line; do
+DOCKER_COMPOSE_FILE=${1:-docker-compose.prod.yml}
+
+sudo docker compose -f "$DOCKER_COMPOSE_FILE" logs -f api 2>/dev/null | while read -r line; do
   if [[ "$line" == *"accepted"* ]]; then
     ((current_connections++))
     if ((current_connections > max_connections)); then

--- a/monitor_connections.sh
+++ b/monitor_connections.sh
@@ -3,7 +3,7 @@
 connection_count=0
 max_connection_count=0
 
-sudo docker compose -f docker-compose.prod.yml logs -f api | while read -r line
+sudo docker compose -f docker-compose.prod.yml logs -f api 2>/dev/null | while read -r line
 do
   if echo "$line" | grep -q "accepted"; then
     ((connection_count++))

--- a/monitor_connections.sh
+++ b/monitor_connections.sh
@@ -10,8 +10,8 @@ do
     if (( connection_count > max_connection_count )); then
       max_connection_count=$connection_count
     fi
-  elif echo "$line" | grep -q "\"type\":\"closed\""; then
+  elif echo "$line" | grep -q "closed"; then
     ((connection_count--))
   fi
-  echo -ne "現在の同時接続数: $((connection_count / 2)), 最大同時接続数: $((max_connection_count / 2))\r"
+  echo -ne "現在の同時接続数: $connection_count, 最大同時接続数: $max_connection_count\r"
 done


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->

# 対応Issue

<!-- 対応したIssue番号を記載 -->

- resolve #175 

# 概要

apiサービスのログを監視して、接続の初期化と終了をカウントするシェルスクリプトを作成しました。

<!-- 開発内容の概要を記載 -->

# 実装詳細

`accepted`メッセージを検出して接続数を増やし、`closed`メッセージを検出して接続数を減らしています。
実行前に実行権限をつけないとダメかも → `chmod +x monitor_connections.sh`
docker-composeファイルの引数なしで実行すると、docker-compose.prod.ymlで処理されます。

<!-- 具体的な開発内容を記載 -->

# 画面スクリーンショット等

<!-- URLとともに貼る（なければ空欄でよい） -->

![image](https://github.com/user-attachments/assets/9fc4beda-075c-4138-b084-49ef8bc17bf4)


# テスト項目

<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->

- [ ] `./monitor_connections.sh <docker-compose-file>` でスクリプトを実行します。
- [ ] ユーザーページを開く数の増減で現在の同時接続数と最大同時接続数が更新される。