### PR TITLE
抽選番号の表示順をlocalstorageへ保存する機能を実装

### DIFF
--- a/view-user/src/components/Layout/Layout.tsx
+++ b/view-user/src/components/Layout/Layout.tsx
@@ -56,7 +56,7 @@ const Layout = (props: LayoutProps) => {
     useState<boolean>(false);
   const [isSettingsModalOpen, setIsSettingsModalOpen] =
     useState<boolean>(false);
-  const [isSortOrderActive, setIsSortOrderActive] = useState(false);
+  const [isSortOrderActive, setIsSortOrderActive] = useState<boolean>(false);
   const [isReachModalOpen, setIsReachModalOpen] = useState<boolean>(false);
   const [isReachIconVisible, setReachIconVisible] = useState<boolean>(true);
   const [isFlag, setIsFlag] = useState<boolean>(false);
@@ -90,6 +90,15 @@ const Layout = (props: LayoutProps) => {
     if (storedVisibility !== null) {
       setReachIconVisible(storedVisibility === "true");
     }
+
+    const storedSortOrder = localStorage.getItem("isSortedAscending");
+    if (storedSortOrder !== null) {
+      const isSortedAscending = storedSortOrder === "true";
+      props.setIsSortedAscending?.(isSortedAscending);
+      setIsSortOrderActive(isSortedAscending);
+    } else {
+      localStorage.setItem("isSortedAscending", "false");
+    }
   }, []);
 
   const handleReactionsiconClick = (id: number) => {
@@ -118,9 +127,11 @@ const Layout = (props: LayoutProps) => {
 
   const toggleSortOrder = () => {
     if (props.setIsSortedAscending) {
-      props.setIsSortedAscending(!props.isSortedAscending);
+      const newSortOrder = !props.isSortedAscending;
+      localStorage.setItem("isSortedAscending", newSortOrder.toString());
+      props.setIsSortedAscending(newSortOrder);
+      setIsSortOrderActive(newSortOrder);
     }
-    setIsSortOrderActive(!isSortOrderActive);
   };
 
   const toggleLanguage = () => {

--- a/view-user/src/pages/index.tsx
+++ b/view-user/src/pages/index.tsx
@@ -23,8 +23,8 @@ const getDisplayBingoNumbers = (
   const firstBingoNumber = getFirstBingoNumber(bingoNumbers);
   const sortedBingoNumber = getSortedBingoNumber(bingoNumbers);
   return isSortedAscending
-    ? { large: firstBingoNumber, list: bingoNumbers.slice(0, -1).reverse() }
-    : { list: sortedBingoNumber };
+    ? { list: sortedBingoNumber }
+    : { large: firstBingoNumber, list: bingoNumbers.slice(0, -1).reverse() };
 };
 
 const Page: NextPage = () => {
@@ -71,7 +71,7 @@ const Page: NextPage = () => {
         setLanguage={setLanguage}
       >
         <div className={styles.numberCardLarge}>
-          {isSortedAscending && displayBingoNumbers.large && (
+          {!isSortedAscending && displayBingoNumbers.large && (
             <NumberCardLarge bingoNumber={displayBingoNumbers.large} />
           )}
           <NumberCardList bingoNumber={displayBingoNumbers.list} />


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->

# 対応Issue

<!-- 対応したIssue番号を記載 -->

- resolve #296 

# 概要

<!-- 開発内容の概要を記載 -->

ページリロードで抽選番号の表示順がリセットされてしまうの問題を修正した。

# 実装詳細

<!-- 具体的な開発内容を記載 -->

ページ読み込み時にlocalStorageへ`isSortedAscending`をfalseで登録し、`toggleSortOrder`の稼働時にlocalstorageのbool値にも変更を反映させています。

# 画面スクリーンショット等

<!-- URLとともに貼る（なければ空欄でよい） -->
<img src="https://github.com/user-attachments/assets/71210bd9-85b2-4370-bf7d-64bd663c3ca7" width="50%" />


# テスト項目

<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->

- [ ] 並び順切り替え用のトグルを変更後、ページをリロードしても並び順が維持される。