### PR TITLE
リアクション降下のリファクタ

### DIFF
--- a/view-user/package-lock.json
+++ b/view-user/package-lock.json
@@ -4227,7 +4227,6 @@
       "resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-8.1.0.tgz",
       "integrity": "sha512-LnhVjMWyMQV9ZmeEy26maJk+8HTIbd59cH4F2MJ439k9DqejRisfFNGAPvRYlKETuh9LrImlS8aKsBgKjMA8WA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@babel/plugin-transform-react-constant-elements": "^7.21.3",

--- a/view-user/src/pages/screen/index.tsx
+++ b/view-user/src/pages/screen/index.tsx
@@ -1,5 +1,4 @@
 import type { NextPage } from "next";
-import Image from "next/image";
 import { useState, useEffect, useRef } from "react";
 import Matter from "matter-js";
 import { useSubscription } from "@apollo/client";
@@ -7,11 +6,9 @@ import {
   SubscribeListNumbersDocument,
   SubscribeCreatedStampTriggerDocument,
   SubscribeOneLatestReachLogDocument,
-} from "@/types/graphql";
-import type {
-  SubscribeListNumbersSubscription,
-  SubscribeCreatedStampTriggerSubscription,
-  SubscribeOneLatestReachLogSubscription,
+  type SubscribeListNumbersSubscription,
+  type SubscribeCreatedStampTriggerSubscription,
+  type SubscribeOneLatestReachLogSubscription,
 } from "@/types/graphql";
 import {
   NumberCardLarge,
@@ -69,7 +66,7 @@ const Page: NextPage = () => {
   const render = useRef<Matter.Render | null>(null);
   const engine = useRef<Matter.Engine | null>(null);
   const [latestCreatedAt, setLatestCreatedAt] = useState<string>(
-    new Date().toString(),
+    new Date().toISOString(),
   );
   const [bingoNumbers, setBingoNumbers] = useState<
     SubscribeListNumbersSubscription["numbers"]
@@ -100,21 +97,23 @@ const Page: NextPage = () => {
     );
 
   useEffect(() => {
-    if (triggers?.stampTriggers?.length) {
-      triggers.stampTriggers.forEach((stamp: Stamp) => {
+    const stamps = triggers?.stampTriggers;
+    if (stamps?.length) {
+      stamps.forEach((stamp: Stamp) => {
         addCircleById(stamp.name);
-
-        if (
-          stamp.createdAt &&
-          new Date(stamp.createdAt) > new Date(latestCreatedAt)
-        ) {
-          setLatestCreatedAt(stamp.createdAt);
-        }
       });
 
-      setLatestCreatedAt(latestCreatedAt);
+      const latestStamp = stamps.reduce((latest, stamp) => {
+        return new Date(stamp.createdAt) > new Date(latest.createdAt)
+          ? stamp
+          : latest;
+      }, stamps[0]);
+
+      if (new Date(latestStamp.createdAt) > new Date(latestCreatedAt)) {
+        setLatestCreatedAt(latestStamp.createdAt);
+      }
     }
-  }, [triggers]);
+  }, [triggers, latestCreatedAt]);
 
   // ビンゴ番号のuseEffect
   useEffect(() => {
@@ -174,15 +173,7 @@ const Page: NextPage = () => {
         background: "transparent",
       },
     });
-
-    const ground = Bodies.rectangle(
-      window.innerWidth / 2,
-      window.innerHeight,
-      window.innerWidth + 10,
-      20,
-      { isStatic: true, render: { visible: false } },
-    );
-
+    
     const rightWall = Bodies.rectangle(
       window.innerWidth,
       window.innerHeight / 2,
@@ -199,7 +190,7 @@ const Page: NextPage = () => {
       { isStatic: true, render: { visible: false } },
     );
 
-    Composite.add(engine.current.world, [ground, leftWall, rightWall]);
+    Composite.add(engine.current.world, [leftWall, rightWall]);
     Render.run(render.current);
 
     const runner = Runner.create();

--- a/view-user/src/pages/screen/index.tsx
+++ b/view-user/src/pages/screen/index.tsx
@@ -173,7 +173,7 @@ const Page: NextPage = () => {
         background: "transparent",
       },
     });
-    
+
     const rightWall = Bodies.rectangle(
       window.innerWidth,
       window.innerHeight / 2,


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->

# 対応Issue

<!-- 対応したIssue番号を記載 -->

- resolve #317

# 概要

リアクションの床判定を削除しました。
リアクション降下のuseEffectをリファクタしました。
types/graqhQlのimport文の修正
latestCreatedAtの初期値修正

# 実装詳細

<!-- 具体的な開発内容を記載 -->
床判定であるgroundを削除しました。
latestCreatedAtの更新が見づらかったので行分けしました。

# 画面スクリーンショット等

https://github.com/user-attachments/assets/f5ae0ecb-ff58-451d-a19d-793ed34bb52f


<!-- URLとともに貼る（なければ空欄でよい） -->

# テスト項目

<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->

- [ ] リアクションが降下されるか
- [ ] リアクションが落ちていくか
- [ ] リロード時に今までのリアクションが降ってこないか。

# 備考

<!-- 実装していて困った箇所・質問など -->
package.lock.jsonが変更されてたけどpushしてよかったのでしょうか。。。。