### PR TITLE
React-Colorの導入&モーダルにカラーパレットの導入

### DIFF
--- a/view-user/package-lock.json
+++ b/view-user/package-lock.json
@@ -28,6 +28,7 @@
         "minio": "^7.1.1",
         "next": "^14.2.3",
         "react": "^18.3.1",
+        "react-color": "^2.19.3",
         "react-dom": "^18.3.1",
         "react-icons": "^4.10.1",
         "recoil": "^0.7.7"
@@ -42,6 +43,7 @@
         "@svgr/webpack": "^8.1.0",
         "@types/matter-js": "^0.19.6",
         "@types/minio": "^7.1.1",
+        "@types/react-color": "^3.0.12",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
         "prettier": "^3.2.5",
@@ -3564,6 +3566,15 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
     },
+    "node_modules/@icons/material": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
+      "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -4325,10 +4336,31 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@types/react-color": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@types/react-color/-/react-color-3.0.12.tgz",
+      "integrity": "sha512-pr3uKE3lSvf7GFo1Rn2K3QktiZQFFrSgSGJ/3iMvSOYWt2pPAJ97rVdVfhWxYJZ8prAEXzoP2XX//3qGSQgu7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*",
+        "@types/reactcss": "*"
+      }
+    },
     "node_modules/@types/react-dom": {
       "version": "18.2.5",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.5.tgz",
       "integrity": "sha512-sRQsOS/sCLnpQhR4DSKGTtWFE3FZjpQa86KPVbhUqdYMRZ9FEFcfAytKhR/vUG2rH1oFbOOej6cuD7MFSobDRQ==",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/reactcss": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@types/reactcss/-/reactcss-1.2.12.tgz",
+      "integrity": "sha512-BrXUQ86/wbbFiZv8h/Q1/Q1XOsaHneYmCb/tHe9+M8XBAAUc2EHfdY0DY22ZZjVSaXr5ix7j+zsqO2eGZub8lQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/react": "*"
       }
@@ -8829,6 +8861,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
@@ -8983,6 +9021,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/material-colors": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
+      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==",
+      "license": "ISC"
     },
     "node_modules/matter-js": {
       "version": "0.19.0",
@@ -9939,6 +9983,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-color": {
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
+      "integrity": "sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@icons/material": "^0.2.4",
+        "lodash": "^4.17.15",
+        "lodash-es": "^4.17.15",
+        "material-colors": "^1.2.1",
+        "prop-types": "^15.5.10",
+        "reactcss": "^1.2.0",
+        "tinycolor2": "^1.4.1"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -9963,6 +10025,15 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/reactcss": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
+      "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.0.1"
+      }
     },
     "node_modules/read-pkg": {
       "version": "1.1.0",
@@ -10998,6 +11069,12 @@
       "dependencies": {
         "readable-stream": "3"
       }
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
     },
     "node_modules/title-case": {
       "version": "3.0.3",

--- a/view-user/package.json
+++ b/view-user/package.json
@@ -31,6 +31,7 @@
     "minio": "^7.1.1",
     "next": "^14.2.3",
     "react": "^18.3.1",
+    "react-color": "^2.19.3",
     "react-dom": "^18.3.1",
     "react-icons": "^4.10.1",
     "recoil": "^0.7.7"
@@ -45,6 +46,7 @@
     "@svgr/webpack": "^8.1.0",
     "@types/matter-js": "^0.19.6",
     "@types/minio": "^7.1.1",
+    "@types/react-color": "^3.0.12",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "prettier": "^3.2.5",

--- a/view-user/src/components/Layout/Layout.module.css
+++ b/view-user/src/components/Layout/Layout.module.css
@@ -49,3 +49,7 @@
   text-align: center;
   margin-bottom: 3.5vw;
 }
+
+.resetButton > button {
+  width: auto;
+}

--- a/view-user/src/components/Layout/Layout.tsx
+++ b/view-user/src/components/Layout/Layout.tsx
@@ -1,5 +1,5 @@
 import { useLazyQuery, useMutation } from "@apollo/client";
-import { useState, useEffect, useRef, useLayoutEffect } from "react";
+import { useState, useRef, useLayoutEffect, useEffect } from "react";
 import { useRouter } from "next/router";
 import styles from "./Layout.module.css";
 import {
@@ -82,15 +82,20 @@ interface LayoutProps {
 const Layout = (props: LayoutProps) => {
   const router = useRouter();
   const t = props.language === "ja" ? ja : en;
+
   const [isReactionModalOpen, setIsReactionModalOpen] = useState(false);
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
+
   const [isSortOrderActive, setIsSortOrderActive] = useState(false);
+  const { setIsSortedAscending } = props;
+
   const [isReachModalOpen, setIsReachModalOpen] = useState(false);
   const [isReachIconVisible, setReachIconVisible] = useState(true);
-  const [navBarHeight, setNavBarHeight] = useState<string>();
+
   const [mainColor, setMainColor] = useState(COLOR_PRESETS.DEFAULT_MAIN_COLOR);
   const [subColor, setSubColor] = useState(COLOR_PRESETS.DEFAULT_SUB_COLOR);
 
+  const [navBarHeight, setNavBarHeight] = useState<string>();
   const navRef = useRef<HTMLDivElement>(null);
   const position = isReachIconVisible ? "29%" : "50%";
 
@@ -98,9 +103,11 @@ const Layout = (props: LayoutProps) => {
     CreateOneStampTriggerMutation,
     CreateOneStampTriggerMutationVariables
   >(CreateOneStampTriggerDocument);
+
   const [getLatestReachLog] = useLazyQuery<GetOneLatestReachLogQuery>(
     GetOneLatestReachLogDocument,
   );
+
   const [createOneReachRecord] = useMutation<
     CreateOneReachRecordMutation,
     CreateOneReachRecordMutationVariables
@@ -116,51 +123,30 @@ const Layout = (props: LayoutProps) => {
 
   // ローカルストレージから設定を読み込む
   useEffect(() => {
-    // リーチアイコンの表示状態を読み込む
-    const storedVisibility = localStorage.getItem("isReachIconVisible");
-    if (storedVisibility !== null) {
-      setReachIconVisible(storedVisibility === "true");
-    }
-
-    // ソート順を読み込む
     const storedSortOrder = localStorage.getItem("isSortedAscending");
-    if (storedSortOrder !== null) {
-      const isSortedAscending = storedSortOrder === "true";
-      props.setIsSortedAscending?.(isSortedAscending);
-      setIsSortOrderActive(isSortedAscending);
-    } else {
-      localStorage.setItem("isSortedAscending", "false");
-    }
-
-    // メインカラーを読み込む
+    const storedVisibility = localStorage.getItem("isReachIconVisible");
     const storedMainColor = localStorage.getItem("mainColor");
-    if (storedMainColor) {
-      setMainColor(storedMainColor);
-      document.documentElement.style.setProperty(
-        "--main-color",
-        storedMainColor,
-      );
-    } else {
-      setMainColor(COLOR_PRESETS.DEFAULT_MAIN_COLOR);
-      document.documentElement.style.setProperty(
-        "--main-color",
-        COLOR_PRESETS.DEFAULT_MAIN_COLOR,
-      );
-    }
-
-    // サブカラーを読み込む
     const storedSubColor = localStorage.getItem("subColor");
-    if (storedSubColor) {
-      setSubColor(storedSubColor);
-      document.documentElement.style.setProperty("--sub-color", storedSubColor);
-    } else {
-      setSubColor(COLOR_PRESETS.DEFAULT_SUB_COLOR);
-      document.documentElement.style.setProperty(
-        "--sub-color",
-        COLOR_PRESETS.DEFAULT_SUB_COLOR,
-      );
-    }
-  }, [props]);
+
+    setIsSortOrderActive(
+      storedSortOrder !== null ? storedSortOrder === "true" : false,
+    );
+    setReachIconVisible(
+      storedVisibility !== null ? storedVisibility === "true" : true,
+    );
+    setMainColor(storedMainColor || COLOR_PRESETS.DEFAULT_MAIN_COLOR);
+    setSubColor(storedSubColor || COLOR_PRESETS.DEFAULT_SUB_COLOR);
+  }, []);
+
+  // 初期設定を適用
+  useEffect(() => {
+    // ソート順を親コンポーネントに伝える
+    setIsSortedAscending?.(isSortOrderActive);
+
+    // カラーを適用
+    document.documentElement.style.setProperty("--main-color", mainColor);
+    document.documentElement.style.setProperty("--sub-color", subColor);
+  }, [isSortOrderActive, mainColor, subColor, setIsSortedAscending]);
 
   // リアクションアイコンがクリックされたときの処理
   const handleReactionClick = (name: string) => {
@@ -189,12 +175,10 @@ const Layout = (props: LayoutProps) => {
 
   // ソート順を切り替える
   const toggleSortOrder = () => {
-    if (props.setIsSortedAscending) {
-      const newSortOrder = !props.isSortedAscending;
-      localStorage.setItem("isSortedAscending", newSortOrder.toString());
-      props.setIsSortedAscending(newSortOrder);
-      setIsSortOrderActive(newSortOrder);
-    }
+    const newSortOrder = !isSortOrderActive;
+    localStorage.setItem("isSortedAscending", newSortOrder.toString());
+    setIsSortedAscending?.(newSortOrder);
+    setIsSortOrderActive(newSortOrder);
   };
 
   // 言語を切り替える

--- a/view-user/src/components/Layout/Layout.tsx
+++ b/view-user/src/components/Layout/Layout.tsx
@@ -66,8 +66,8 @@ const COLOR_PRESETS = {
     "#FCDBE3",
     "#E4BBFA",
   ],
-  DEFAULT_MAIN_COLOR: "#20a0d8",
-  DEFAULT_SUB_COLOR: "#c4deed",
+  DEFAULT_MAIN_COLOR: "#20A0D8",
+  DEFAULT_SUB_COLOR: "#C4DEED",
 };
 
 interface LayoutProps {

--- a/view-user/src/components/Layout/Layout.tsx
+++ b/view-user/src/components/Layout/Layout.tsx
@@ -28,6 +28,7 @@ import type {
   GetOneLatestReachLogQuery,
 } from "@/types/graphql";
 import { ja, en } from "@/locales";
+import { TwitterPicker } from "react-color";
 
 const images = [
   { name: "crap", src: "/ReactionIcon/crap.png", alt: "crap icon" },
@@ -60,6 +61,12 @@ const Layout = (props: LayoutProps) => {
   const [isReachModalOpen, setIsReachModalOpen] = useState<boolean>(false);
   const [isReachIconVisible, setReachIconVisible] = useState<boolean>(true);
   const [navBarHeight, setNavBarHeight] = useState<string>();
+
+  const DEFAULT_MAIN_COLOR = "#20a0d8";
+  const DEFAULT_SUB_COLOR = "#c4deed";
+  const [mainColor, setMainColor] = useState<string>(DEFAULT_MAIN_COLOR);
+  const [subColor, setSubColor] = useState<string>(DEFAULT_SUB_COLOR);
+
   const navRef = useRef<HTMLDivElement>(null);
   const position: string = isReachIconVisible ? "29%" : "50%";
   const [createStampRecord] = useMutation<
@@ -74,7 +81,7 @@ const Layout = (props: LayoutProps) => {
     CreateOneReachRecordMutation,
     CreateOneReachRecordMutationVariables
   >(CreateOneReachRecordDocument);
-  5;
+
   // navBarの高さをstring型で渡す
   useLayoutEffect(() => {
     if (navRef.current) {
@@ -85,20 +92,55 @@ const Layout = (props: LayoutProps) => {
 
   // localStorageから状態を読み込む
   useEffect(() => {
-    const storedVisibility = localStorage.getItem("isReachIconVisible");
-    if (storedVisibility !== null) {
-      setReachIconVisible(storedVisibility === "true");
-    }
+    const loadStoredSettings = () => {
+      const storedVisibility = localStorage.getItem("isReachIconVisible");
+      if (storedVisibility !== null) {
+        setReachIconVisible(storedVisibility === "true");
+      }
 
-    const storedSortOrder = localStorage.getItem("isSortedAscending");
-    if (storedSortOrder !== null) {
-      const isSortedAscending = storedSortOrder === "true";
-      props.setIsSortedAscending?.(isSortedAscending);
-      setIsSortOrderActive(isSortedAscending);
-    } else {
-      localStorage.setItem("isSortedAscending", "false");
-    }
-  }, []);
+      const storedSortOrder = localStorage.getItem("isSortedAscending");
+      if (storedSortOrder !== null) {
+        const isSortedAscending = storedSortOrder === "true";
+        props.setIsSortedAscending?.(isSortedAscending);
+        setIsSortOrderActive(isSortedAscending);
+      } else {
+        localStorage.setItem("isSortedAscending", "false");
+      }
+
+      const storedMainColor = localStorage.getItem("mainColor");
+      const storedSubColor = localStorage.getItem("subColor");
+
+      if (storedMainColor) {
+        setMainColor(storedMainColor);
+        document.documentElement.style.setProperty(
+          "--main-color",
+          storedMainColor,
+        );
+      } else {
+        setMainColor(DEFAULT_MAIN_COLOR);
+        document.documentElement.style.setProperty(
+          "--main-color",
+          DEFAULT_MAIN_COLOR,
+        );
+      }
+
+      if (storedSubColor) {
+        setSubColor(storedSubColor);
+        document.documentElement.style.setProperty(
+          "--sub-color",
+          storedSubColor,
+        );
+      } else {
+        setSubColor(DEFAULT_SUB_COLOR);
+        document.documentElement.style.setProperty(
+          "--sub-color",
+          DEFAULT_SUB_COLOR,
+        );
+      }
+    };
+
+    loadStoredSettings();
+  }, [props]);
 
   const handleReactionClick = (name: string) => {
     createStampRecord({ variables: { name } });
@@ -135,6 +177,20 @@ const Layout = (props: LayoutProps) => {
   const toggleLanguage = () => {
     const newLocale = props.language === "ja" ? "en" : "ja";
     router.push(router.pathname, router.asPath, { locale: newLocale });
+  };
+
+  const handleMainColorChange = (color: any) => {
+    const newColor = color.hex;
+    setMainColor(newColor);
+    localStorage.setItem("mainColor", newColor);
+    document.documentElement.style.setProperty("--main-color", newColor);
+  };
+
+  const handleSubColorChange = (color: any) => {
+    const newColor = color.hex;
+    setSubColor(newColor);
+    localStorage.setItem("subColor", newColor);
+    document.documentElement.style.setProperty("--sub-color", newColor);
   };
 
   const icons = (pageName: string) => {
@@ -219,6 +275,46 @@ const Layout = (props: LayoutProps) => {
               <span>{t.settingsModal.drawOrder}</span>
               <span>{t.settingsModal.ascending}</span>
             </ToggleButton>
+          </div>
+          <div>
+            <p>メインカラー</p>
+            <TwitterPicker
+              color={mainColor}
+              colors={[
+                "#FF6900",
+                "#FCB900",
+                "#7BDCB5",
+                "#00D084",
+                "#8ED1FC",
+                "#0693E3",
+                "#333333",
+                "#EB144C",
+                "#F78DA7",
+                "#9900EF",
+              ]}
+              triangle="hide"
+              onChange={handleMainColorChange}
+            />
+          </div>
+          <div>
+            <p>サブカラー</p>
+            <TwitterPicker
+              color={subColor}
+              colors={[
+                "#FFD9BE",
+                "#FDECBD",
+                "#C2EFDD",
+                "#C3F5E3",
+                "#DBF0FE",
+                "#C0E4F8",
+                "#B1B1B1",
+                "#FDECF0",
+                "#FCDBE3",
+                "#E4BBFA",
+              ]}
+              triangle="hide"
+              onChange={handleSubColorChange}
+            />
           </div>
         </div>
       </Modal>

--- a/view-user/src/components/Layout/Layout.tsx
+++ b/view-user/src/components/Layout/Layout.tsx
@@ -41,6 +41,35 @@ const images = [
   { name: "sad", src: "/ReactionIcon/sad.png", alt: "sad icon" },
 ];
 
+const COLOR_PRESETS = {
+  MAIN_COLORS: [
+    "#FF6900",
+    "#FCB900",
+    "#7BDCB5",
+    "#00D084",
+    "#8ED1FC",
+    "#0693E3",
+    "#333333",
+    "#EB144C",
+    "#F78DA7",
+    "#9900EF",
+  ],
+  SUB_COLORS: [
+    "#FFD9BE",
+    "#FDECBD",
+    "#C2EFDD",
+    "#C3F5E3",
+    "#DBF0FE",
+    "#C0E4F8",
+    "#B1B1B1",
+    "#FDECF0",
+    "#FCDBE3",
+    "#E4BBFA",
+  ],
+  DEFAULT_MAIN_COLOR: "#20a0d8",
+  DEFAULT_SUB_COLOR: "#c4deed",
+};
+
 interface LayoutProps {
   children: React.ReactNode;
   pageName: string;
@@ -53,22 +82,18 @@ interface LayoutProps {
 const Layout = (props: LayoutProps) => {
   const router = useRouter();
   const t = props.language === "ja" ? ja : en;
-  const [isReactionModalOpen, setIsReactionModalOpen] =
-    useState<boolean>(false);
-  const [isSettingsModalOpen, setIsSettingsModalOpen] =
-    useState<boolean>(false);
-  const [isSortOrderActive, setIsSortOrderActive] = useState<boolean>(false);
-  const [isReachModalOpen, setIsReachModalOpen] = useState<boolean>(false);
-  const [isReachIconVisible, setReachIconVisible] = useState<boolean>(true);
+  const [isReactionModalOpen, setIsReactionModalOpen] = useState(false);
+  const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
+  const [isSortOrderActive, setIsSortOrderActive] = useState(false);
+  const [isReachModalOpen, setIsReachModalOpen] = useState(false);
+  const [isReachIconVisible, setReachIconVisible] = useState(true);
   const [navBarHeight, setNavBarHeight] = useState<string>();
-
-  const DEFAULT_MAIN_COLOR = "#20a0d8";
-  const DEFAULT_SUB_COLOR = "#c4deed";
-  const [mainColor, setMainColor] = useState<string>(DEFAULT_MAIN_COLOR);
-  const [subColor, setSubColor] = useState<string>(DEFAULT_SUB_COLOR);
+  const [mainColor, setMainColor] = useState(COLOR_PRESETS.DEFAULT_MAIN_COLOR);
+  const [subColor, setSubColor] = useState(COLOR_PRESETS.DEFAULT_SUB_COLOR);
 
   const navRef = useRef<HTMLDivElement>(null);
-  const position: string = isReachIconVisible ? "29%" : "50%";
+  const position = isReachIconVisible ? "29%" : "50%";
+
   const [createStampRecord] = useMutation<
     CreateOneStampTriggerMutation,
     CreateOneStampTriggerMutationVariables
@@ -76,13 +101,12 @@ const Layout = (props: LayoutProps) => {
   const [getLatestReachLog] = useLazyQuery<GetOneLatestReachLogQuery>(
     GetOneLatestReachLogDocument,
   );
-
   const [createOneReachRecord] = useMutation<
     CreateOneReachRecordMutation,
     CreateOneReachRecordMutationVariables
   >(CreateOneReachRecordDocument);
 
-  // navBarの高さをstring型で渡す
+  // ナビゲーションバーの高さを設定
   useLayoutEffect(() => {
     if (navRef.current) {
       const navHeight = navRef.current.getBoundingClientRect().height;
@@ -90,62 +114,60 @@ const Layout = (props: LayoutProps) => {
     }
   }, []);
 
-  // localStorageから状態を読み込む
+  // ローカルストレージから設定を読み込む
   useEffect(() => {
-    const loadStoredSettings = () => {
-      const storedVisibility = localStorage.getItem("isReachIconVisible");
-      if (storedVisibility !== null) {
-        setReachIconVisible(storedVisibility === "true");
-      }
+    // リーチアイコンの表示状態を読み込む
+    const storedVisibility = localStorage.getItem("isReachIconVisible");
+    if (storedVisibility !== null) {
+      setReachIconVisible(storedVisibility === "true");
+    }
 
-      const storedSortOrder = localStorage.getItem("isSortedAscending");
-      if (storedSortOrder !== null) {
-        const isSortedAscending = storedSortOrder === "true";
-        props.setIsSortedAscending?.(isSortedAscending);
-        setIsSortOrderActive(isSortedAscending);
-      } else {
-        localStorage.setItem("isSortedAscending", "false");
-      }
+    // ソート順を読み込む
+    const storedSortOrder = localStorage.getItem("isSortedAscending");
+    if (storedSortOrder !== null) {
+      const isSortedAscending = storedSortOrder === "true";
+      props.setIsSortedAscending?.(isSortedAscending);
+      setIsSortOrderActive(isSortedAscending);
+    } else {
+      localStorage.setItem("isSortedAscending", "false");
+    }
 
-      const storedMainColor = localStorage.getItem("mainColor");
-      const storedSubColor = localStorage.getItem("subColor");
+    // メインカラーを読み込む
+    const storedMainColor = localStorage.getItem("mainColor");
+    if (storedMainColor) {
+      setMainColor(storedMainColor);
+      document.documentElement.style.setProperty(
+        "--main-color",
+        storedMainColor,
+      );
+    } else {
+      setMainColor(COLOR_PRESETS.DEFAULT_MAIN_COLOR);
+      document.documentElement.style.setProperty(
+        "--main-color",
+        COLOR_PRESETS.DEFAULT_MAIN_COLOR,
+      );
+    }
 
-      if (storedMainColor) {
-        setMainColor(storedMainColor);
-        document.documentElement.style.setProperty(
-          "--main-color",
-          storedMainColor,
-        );
-      } else {
-        setMainColor(DEFAULT_MAIN_COLOR);
-        document.documentElement.style.setProperty(
-          "--main-color",
-          DEFAULT_MAIN_COLOR,
-        );
-      }
-
-      if (storedSubColor) {
-        setSubColor(storedSubColor);
-        document.documentElement.style.setProperty(
-          "--sub-color",
-          storedSubColor,
-        );
-      } else {
-        setSubColor(DEFAULT_SUB_COLOR);
-        document.documentElement.style.setProperty(
-          "--sub-color",
-          DEFAULT_SUB_COLOR,
-        );
-      }
-    };
-
-    loadStoredSettings();
+    // サブカラーを読み込む
+    const storedSubColor = localStorage.getItem("subColor");
+    if (storedSubColor) {
+      setSubColor(storedSubColor);
+      document.documentElement.style.setProperty("--sub-color", storedSubColor);
+    } else {
+      setSubColor(COLOR_PRESETS.DEFAULT_SUB_COLOR);
+      document.documentElement.style.setProperty(
+        "--sub-color",
+        COLOR_PRESETS.DEFAULT_SUB_COLOR,
+      );
+    }
   }, [props]);
 
+  // リアクションアイコンがクリックされたときの処理
   const handleReactionClick = (name: string) => {
     createStampRecord({ variables: { name } });
   };
 
+  // リーチアイコンがクリックされたときの処理
   const handleReachIconClick = async () => {
     try {
       const { data } = await getLatestReachLog();
@@ -165,6 +187,7 @@ const Layout = (props: LayoutProps) => {
     }
   };
 
+  // ソート順を切り替える
   const toggleSortOrder = () => {
     if (props.setIsSortedAscending) {
       const newSortOrder = !props.isSortedAscending;
@@ -174,42 +197,46 @@ const Layout = (props: LayoutProps) => {
     }
   };
 
+  // 言語を切り替える
   const toggleLanguage = () => {
     const newLocale = props.language === "ja" ? "en" : "ja";
     router.push(router.pathname, router.asPath, { locale: newLocale });
   };
 
-  const handleMainColorChange = (color: any) => {
+  // メインカラーを変更する
+  const handleMainColorChange = (color: { hex: string }) => {
     const newColor = color.hex;
     setMainColor(newColor);
     localStorage.setItem("mainColor", newColor);
     document.documentElement.style.setProperty("--main-color", newColor);
   };
 
-  const handleSubColorChange = (color: any) => {
+  // サブカラーを変更する
+  const handleSubColorChange = (color: { hex: string }) => {
     const newColor = color.hex;
     setSubColor(newColor);
     localStorage.setItem("subColor", newColor);
     document.documentElement.style.setProperty("--sub-color", newColor);
   };
 
+  // カラーをリセットする
   const resetColors = () => {
-    setMainColor(DEFAULT_MAIN_COLOR);
-    setSubColor(DEFAULT_SUB_COLOR);
+    setMainColor(COLOR_PRESETS.DEFAULT_MAIN_COLOR);
+    setSubColor(COLOR_PRESETS.DEFAULT_SUB_COLOR);
     localStorage.removeItem("mainColor");
     localStorage.removeItem("subColor");
     document.documentElement.style.setProperty(
       "--main-color",
-      DEFAULT_MAIN_COLOR,
+      COLOR_PRESETS.DEFAULT_MAIN_COLOR,
     );
     document.documentElement.style.setProperty(
       "--sub-color",
-      DEFAULT_SUB_COLOR,
+      COLOR_PRESETS.DEFAULT_SUB_COLOR,
     );
   };
 
+  // ページごとのアイコンを設定する
   const icons = (pageName: string) => {
-    let icons = [];
     const commonIcons = [
       <ReactionsIcon
         isOpen={isReactionModalOpen}
@@ -230,20 +257,18 @@ const Layout = (props: LayoutProps) => {
         setIsSettingsModalOpen={setIsSettingsModalOpen}
       />,
     ];
+
     switch (pageName) {
       case "/":
-        icons = [<PrizesIcon key="prize" />, commonIcons];
-        break;
+        return [<PrizesIcon key="prize" />, ...commonIcons];
       case "/prizes":
-        icons = [<BackIcon key="back" />, commonIcons];
-        break;
+        return [<BackIcon key="back" />, ...commonIcons];
       default:
-        icons = [<PrizesIcon key="prize" />, commonIcons];
+        return [<PrizesIcon key="prize" />, ...commonIcons];
     }
-    return icons.filter(Boolean);
   };
 
-  const iconElements = icons(props.pageName);
+  const iconElements = icons(props.pageName).filter(Boolean);
 
   return (
     <div>
@@ -295,18 +320,7 @@ const Layout = (props: LayoutProps) => {
             <p>メインカラー</p>
             <TwitterPicker
               color={mainColor}
-              colors={[
-                "#FF6900",
-                "#FCB900",
-                "#7BDCB5",
-                "#00D084",
-                "#8ED1FC",
-                "#0693E3",
-                "#333333",
-                "#EB144C",
-                "#F78DA7",
-                "#9900EF",
-              ]}
+              colors={COLOR_PRESETS.MAIN_COLORS}
               triangle="hide"
               onChange={handleMainColorChange}
             />
@@ -315,18 +329,7 @@ const Layout = (props: LayoutProps) => {
             <p>サブカラー</p>
             <TwitterPicker
               color={subColor}
-              colors={[
-                "#FFD9BE",
-                "#FDECBD",
-                "#C2EFDD",
-                "#C3F5E3",
-                "#DBF0FE",
-                "#C0E4F8",
-                "#B1B1B1",
-                "#FDECF0",
-                "#FCDBE3",
-                "#E4BBFA",
-              ]}
+              colors={COLOR_PRESETS.SUB_COLORS}
               triangle="hide"
               onChange={handleSubColorChange}
             />

--- a/view-user/src/components/Layout/Layout.tsx
+++ b/view-user/src/components/Layout/Layout.tsx
@@ -193,6 +193,21 @@ const Layout = (props: LayoutProps) => {
     document.documentElement.style.setProperty("--sub-color", newColor);
   };
 
+  const resetColors = () => {
+    setMainColor(DEFAULT_MAIN_COLOR);
+    setSubColor(DEFAULT_SUB_COLOR);
+    localStorage.removeItem("mainColor");
+    localStorage.removeItem("subColor");
+    document.documentElement.style.setProperty(
+      "--main-color",
+      DEFAULT_MAIN_COLOR,
+    );
+    document.documentElement.style.setProperty(
+      "--sub-color",
+      DEFAULT_SUB_COLOR,
+    );
+  };
+
   const icons = (pageName: string) => {
     let icons = [];
     const commonIcons = [
@@ -315,6 +330,9 @@ const Layout = (props: LayoutProps) => {
               triangle="hide"
               onChange={handleSubColorChange}
             />
+          </div>
+          <div className={styles.resetButton}>
+            <Button onClick={resetColors}>カラーを初期値に戻す</Button>
           </div>
         </div>
       </Modal>

--- a/view-user/src/components/common/Modal/Modal.module.css
+++ b/view-user/src/components/common/Modal/Modal.module.css
@@ -14,13 +14,11 @@
 .content {
   min-width: 87.5vw;
   min-height: 58.1vw;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  max-height: 70vh;
   z-index: 50;
   box-sizing: border-box;
   padding: 10vw;
-  overflow: hidden;
+  overflow: auto;
   background-color: var(--background-color);
   border: 1.3vw solid var(--main-color);
   filter: drop-shadow(1.25vw 1.25vw 0px var(--main-color));


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->

# 対応Issue

<!-- 対応したIssue番号を記載 -->

- resolve #321 

# 概要

<!-- 開発内容の概要を記載 -->

- ユーザーがテーマカラーを簡単に変更できるように，カラーパレットを追加しました．


# 実装詳細

<!-- 具体的な開発内容を記載 -->

- React Colorを導入
- SettingsモーダルにMainカラーとSubカラーを変更するためのカラーパレットを追加．
- カラーのリセットボタンを追加．

# 画面スクリーンショット等

<!-- URLとともに貼る（なければ空欄でよい） -->
<img src="https://github.com/user-attachments/assets/e960d34f-fbec-4f9f-aaa5-900ba785a6cd" width="50%" />


# テスト項目

<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->

- [x] Settingsモーダルを展開し，カラーパレットとリセットボタンが表示される．
- [x] カラー変更の操作が反映される．
- [x] ページの遷移やリロードをしてもカラーの変更が維持される．
