### PR TITLE
[view-admin] 画像送信を関数によるトランザクション貼った。

### DIFF
--- a/api/metadata/databases/default/functions/functions.yaml
+++ b/api/metadata/databases/default/functions/functions.yaml
@@ -1,2 +1,3 @@
+- "!include public_create_prize_with_image.yaml"
 - "!include public_decrement_latest_reach_log.yaml"
 - "!include public_increment_latest_reach_log.yaml"

--- a/api/metadata/databases/default/functions/public_create_prize_with_image.yaml
+++ b/api/metadata/databases/default/functions/public_create_prize_with_image.yaml
@@ -1,0 +1,3 @@
+function:
+  name: create_prize_with_image
+  schema: public

--- a/api/migrations/default/1720521696814_auto/up.sql
+++ b/api/migrations/default/1720521696814_auto/up.sql
@@ -1,4 +1,40 @@
 SET check_function_bodies = false;
+CREATE TABLE public.prizes (
+    id integer NOT NULL,
+    is_won boolean DEFAULT false NOT NULL,
+    image_id integer DEFAULT '-1'::integer NOT NULL,
+    name_jp text DEFAULT '""'::text NOT NULL,
+    name_en text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+COMMENT ON TABLE public.prizes IS 'ビンゴの景品データを格納';
+COMMENT ON COLUMN public.prizes.is_won IS '当選した景品はTrueになる';
+COMMENT ON COLUMN public.prizes.image_id IS 'imagesのidが入る';
+COMMENT ON COLUMN public.prizes.name_jp IS '景品の日本語名';
+COMMENT ON COLUMN public.prizes.name_en IS '景品の英語名';
+CREATE FUNCTION public.create_prize_with_image(p_is_won boolean, p_name_jp text, p_name_en text, p_bucket_name text, p_file_name text, p_file_type text) RETURNS SETOF public.prizes
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+  new_image_id int;
+  new_prize_id int;
+BEGIN
+  -- images テーブルにレコードを挿入し、挿入したレコードのIDを取得
+  INSERT INTO public.images(bucket_name, file_name, file_type, created_at, updated_at)
+  VALUES(p_bucket_name, p_file_name, p_file_type, now(), now())
+  RETURNING id INTO new_image_id;
+  -- prizes テーブルにレコードを挿入し、挿入したレコードのIDを取得
+  INSERT INTO public.prizes(is_won, image_id, name_jp, name_en, created_at, updated_at)
+  VALUES(p_is_won, new_image_id, p_name_jp, p_name_en, now(), now())
+  RETURNING id INTO new_prize_id;
+  -- public.prizes テーブルから、挿入したレコードを返す
+  RETURN QUERY
+    SELECT *
+    FROM public.prizes
+    WHERE id = new_prize_id;
+END;
+$$;
 CREATE TABLE public.reach_logs (
     id integer NOT NULL,
     status boolean DEFAULT false NOT NULL,
@@ -58,6 +94,28 @@ BEGIN
   WHERE id = (SELECT id FROM reach_logs ORDER BY created_at DESC LIMIT 1);
 END;
 $$;
+CREATE FUNCTION public.insert_prize_with_image(p_is_won boolean, p_name_jp text, p_name_en text, p_bucket_name text, p_file_name text, p_file_type text) RETURNS SETOF public.prizes
+    LANGUAGE plpgsql STABLE
+    AS $$
+DECLARE
+  new_image_id int;
+  new_prize_id int;
+BEGIN
+  -- images テーブルにレコードを挿入し、挿入したレコードのIDを取得
+  INSERT INTO public.images(bucket_name, file_name, file_type, created_at, updated_at)
+  VALUES(p_bucket_name, p_file_name, p_file_type, now(), now())
+  RETURNING id INTO new_image_id;
+  -- prizes テーブルにレコードを挿入し、挿入したレコードのIDを取得
+  INSERT INTO public.prizes(is_won, image_id, name_jp, name_en, created_at, updated_at)
+  VALUES(p_is_won, new_image_id, p_name_jp, p_name_en, now(), now())
+  RETURNING id INTO new_prize_id;
+  -- public.prizes テーブルから、挿入したレコードを返す
+  RETURN QUERY
+    SELECT *
+    FROM public.prizes
+    WHERE id = new_prize_id;
+END;
+$$;
 CREATE FUNCTION public.set_current_timestamp_updated_at() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
@@ -102,20 +160,6 @@ CREATE SEQUENCE public.numbers_id_seq
     NO MAXVALUE
     CACHE 1;
 ALTER SEQUENCE public.numbers_id_seq OWNED BY public.numbers.id;
-CREATE TABLE public.prizes (
-    id integer NOT NULL,
-    is_won boolean DEFAULT false NOT NULL,
-    image_id integer DEFAULT '-1'::integer NOT NULL,
-    name_jp text DEFAULT '""'::text NOT NULL,
-    name_en text,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL
-);
-COMMENT ON TABLE public.prizes IS 'ビンゴの景品データを格納';
-COMMENT ON COLUMN public.prizes.is_won IS '当選した景品はTrueになる';
-COMMENT ON COLUMN public.prizes.image_id IS 'imagesのidが入る';
-COMMENT ON COLUMN public.prizes.name_jp IS '景品の日本語名';
-COMMENT ON COLUMN public.prizes.name_en IS '景品の英語名';
 CREATE SEQUENCE public.prizes_id_seq
     AS integer
     START WITH 1
@@ -153,6 +197,8 @@ ALTER TABLE ONLY public.reach_logs ALTER COLUMN id SET DEFAULT nextval('public.r
 ALTER TABLE ONLY public.stamp_triggers ALTER COLUMN id SET DEFAULT nextval('public.stamp_triggers_id_seq'::regclass);
 ALTER TABLE ONLY public.images
     ADD CONSTRAINT images_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.numbers
+    ADD CONSTRAINT numbers_number_key UNIQUE (number);
 ALTER TABLE ONLY public.numbers
     ADD CONSTRAINT numbers_pkey PRIMARY KEY (id);
 ALTER TABLE ONLY public.prizes

--- a/view-admin/src/components/common/PrizeResult/PrizeResult.tsx
+++ b/view-admin/src/components/common/PrizeResult/PrizeResult.tsx
@@ -11,7 +11,7 @@ import type {
 
 interface PrizeResultProps {
   prizeResult: GetListPrizesQuery["prizes"];
-  setBingoPrize: React.Dispatch<
+  setBingoPrize?: React.Dispatch<
     React.SetStateAction<GetListPrizesQuery["prizes"]>
   >;
   showOverlay: boolean;
@@ -41,11 +41,13 @@ export const PrizeResult = (props: PrizeResultProps) => {
 
   const handleToggleChange = (id: number, isWon: boolean) => {
     updatePrize({ variables: { id: id, isWon: isWon } });
-    props.setBingoPrize((prev) =>
-      prev.map((prize) =>
-        prize.id === id ? { ...prize, isWon: isWon } : prize,
-      ),
-    );
+    if (props.setBingoPrize) {
+      props.setBingoPrize((prev) =>
+        prev.map((prize) =>
+          prize.id === id ? { ...prize, isWon: isWon } : prize,
+        ),
+      );
+    }
   };
 
   return (

--- a/view-admin/src/gql/prize_with_image.gql
+++ b/view-admin/src/gql/prize_with_image.gql
@@ -1,0 +1,27 @@
+mutation CreatePrizeWithImage(
+  $isWon: Boolean!
+  $nameJp: String!
+  $nameEn: String!
+  $bucketName: String!
+  $fileName: String!
+  $fileType: String!
+) {
+  createPrizeWithImage(
+    args: {
+      p_is_won: $isWon
+      p_name_jp: $nameJp
+      p_name_en: $nameEn
+      p_bucket_name: $bucketName
+      p_file_name: $fileName
+      p_file_type: $fileType
+    }
+  ) {
+    id
+    isWon
+    imageId
+    nameJp
+    nameEn
+    createdAt
+    updatedAt
+  }
+}

--- a/view-admin/src/pages/api/minio.ts
+++ b/view-admin/src/pages/api/minio.ts
@@ -68,7 +68,12 @@ export default async function handler(
           undefined,
           metaData,
         );
-        return res.status(200).json({ message: "Upload successful" });
+        return res.status(200).json({
+          message: "Upload successful",
+          bucketName,
+          fileName,
+          fileType: mimetype,
+        });
       } catch (uploadError) {
         return res.status(500).json({ message: uploadError });
       }

--- a/view-admin/src/pages/postPrizes/index.tsx
+++ b/view-admin/src/pages/postPrizes/index.tsx
@@ -2,56 +2,36 @@ import { useQuery, useMutation } from "@apollo/client";
 /* eslint-disable @next/next/no-img-element */
 import type { NextPage } from "next";
 import styles from "./postPrizes.module.css";
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback, useRef } from "react";
 import { Header, PrizeResult, Loading } from "@/components/common";
 import { IoCloudUploadOutline } from "react-icons/io5";
 import {
   GetListPrizesDocument,
-  CreateOnePrizeDocument,
-  CreateOneImageDocument,
-} from "@/type/graphql";
-import type {
   GetListPrizesQuery,
-  CreateOneImageMutation,
-  CreateOnePrizeMutation,
-  CreateOneImageMutationVariables,
-  CreateOnePrizeMutationVariables,
+  CreatePrizeWithImageMutation,
+  CreatePrizeWithImageDocument,
 } from "@/type/graphql";
 
 import { useRouter } from "next/router";
 
+type PrizeName = {
+  nameJp: string;
+  nameEn: string;
+};
+
 const Page: NextPage = () => {
-  const [bingoPrize, setBingoPrize] = useState<GetListPrizesQuery["prizes"]>(
-    [],
-  );
-  const [prizeNameJp, setPrizeNameJp] = useState<string>("");
-  const [prizeNameEn, setPrizeNameEn] = useState<string>("");
+  const [prizeName, setPrizeName] = useState<PrizeName>({
+    nameJp: "",
+    nameEn: "",
+  });
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [imageFile, setImageFile] = useState<File>();
   const [preview, setPreview] = useState({ uploadImageURL: "", type: "" });
-  const [bucketName, setBucketName] = useState<string>("");
-  const [fileName, setFileName] = useState<string>("");
-  const [fileType, setFileType] = useState<string>("");
   const [isDisabled, setIsDisabled] = useState<boolean>(false);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const { data } = useQuery<GetListPrizesQuery>(GetListPrizesDocument);
-  const [postPrize] = useMutation<
-    CreateOnePrizeMutation,
-    CreateOnePrizeMutationVariables
-  >(CreateOnePrizeDocument);
-  const [postImage] = useMutation<
-    CreateOneImageMutation,
-    CreateOneImageMutationVariables
-  >(CreateOneImageDocument);
-
+  const bingoPrizes: GetListPrizesQuery["prizes"] = data?.prizes ?? [];
   const router = useRouter();
-
-  useEffect(() => {
-    if (data) {
-      setBingoPrize(data.prizes);
-    }
-  }, [data]);
 
   const handleFileChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -65,77 +45,62 @@ const Page: NextPage = () => {
         uploadImageURL: URL.createObjectURL(targetFile),
         type: targetFile.type,
       });
-
-      const bucketName = process.env.NEXT_PUBLIC_BUCKET_NAME;
-      const fileName = targetFile.name;
-      const fileType = targetFile.type;
-
-      setBucketName(bucketName || "");
-      setFileName(fileName);
-      setFileType(fileType);
     },
     [],
   );
-
-  const insertPrize = async (imageId: number) => {
-    postPrize({
-      variables: {
-        isWon: false,
-        imageId: imageId,
-        nameJp: prizeNameJp,
-        nameEn: prizeNameEn,
-      },
-    });
-    setPrizeNameJp("");
-    setPrizeNameEn("");
-    setPreview({ uploadImageURL: "", type: "" });
-    if (fileInputRef.current) {
-      fileInputRef.current.value = "";
-    }
-    setIsDisabled(false);
-    setIsLoading(false);
-  };
-
-  const insertImage = async () => {
-    const result = await postImage({
-      variables: {
-        bucketName: bucketName,
-        fileName: fileName,
-        fileType: fileType,
-      },
-    });
-    // ここでimageIdをuseStateに設定する
-    const imageId = result.data?.insertImagesOne?.id;
-    if (imageId) {
-      insertPrize(imageId);
-    }
-  };
+  const [createPrizeWithImage, loading] =
+    useMutation<CreatePrizeWithImageMutation>(CreatePrizeWithImageDocument);
 
   const postMinio = async () => {
     if (!imageFile) {
       return alert("画像を選択してください");
     }
-    if (prizeNameJp === "") {
+    if (prizeName.nameJp === "") {
       alert("景品名を入力してください。");
-      setIsLoading(false);
       router.reload();
       return;
     }
     const formData = new FormData();
     formData.append("file", imageFile);
-    const fileName = imageFile?.name || "";
-    formData.append("fileName", fileName);
+    const fileNameFromImage = imageFile.name || "";
+    formData.append("fileName", fileNameFromImage);
 
-    const response = await fetch("/api/minio", {
-      method: "POST",
-      body: formData,
-    });
-    insertImage();
+    try {
+      const response = await fetch("/api/minio", {
+        method: "POST",
+        body: formData,
+      });
+      if (!response.ok) {
+        throw new Error("MinIOへのアップロードに失敗しました");
+      }
+      const minioData = await response.json();
+
+      await createPrizeWithImage({
+        variables: {
+          isWon: false,
+          nameJp: prizeName.nameJp,
+          nameEn: prizeName.nameEn,
+          bucketName: minioData.bucketName,
+          fileName: minioData.fileName,
+          fileType: minioData.fileType,
+        },
+      });
+
+      // 登録成功時の処理
+      setPrizeName({ nameJp: "", nameEn: "" });
+      setPreview({ uploadImageURL: "", type: "" });
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    } catch (error) {
+      console.error("画像送信エラー:", error);
+      alert("画像アップロードに失敗しました");
+    }
+    setIsDisabled(false);
   };
 
   const submit = async () => {
     setIsDisabled(true);
-    setIsLoading(true);
     postMinio();
   };
 
@@ -177,7 +142,7 @@ const Page: NextPage = () => {
 
   return (
     <div className={styles.container}>
-      {isLoading && <Loading />}
+      {loading && <Loading />}
       <div>
         <Header user="Admin">
           <button />
@@ -210,12 +175,15 @@ const Page: NextPage = () => {
             <div className={styles.input_details}>
               <h2>景品名を入力</h2>
               <input
-                value={prizeNameJp}
+                value={prizeName.nameJp}
                 className={styles.input_form}
                 type="text"
                 name="name"
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  setPrizeNameJp(e.target.value)
+                  setPrizeName((prev) => ({
+                    ...prev,
+                    nameJp: e.target.value,
+                  }))
                 }
               />
             </div>
@@ -233,8 +201,7 @@ const Page: NextPage = () => {
           </div>
         </div>
         <PrizeResult
-          prizeResult={bingoPrize}
-          setBingoPrize={setBingoPrize}
+          prizeResult={bingoPrizes}
           showToggle={false}
           showOverlay={false}
         />

--- a/view-admin/src/type/graphql.ts
+++ b/view-admin/src/type/graphql.ts
@@ -375,6 +375,8 @@ export type NumbersBoolExp = {
 
 /** unique or primary key constraints on table "numbers" */
 export enum NumbersConstraint {
+  /** unique or primary key constraint on columns "number" */
+  numbersNumberKey = "numbers_number_key",
   /** unique or primary key constraint on columns "id" */
   numbersPkey = "numbers_pkey",
 }
@@ -1327,9 +1329,20 @@ export type TimestamptzComparisonExp = {
   _nin?: InputMaybe<Array<Scalars["timestamptz"]["input"]>>;
 };
 
+export type CreatePrizeWithImageArgs = {
+  p_bucket_name?: InputMaybe<Scalars["String"]["input"]>;
+  p_file_name?: InputMaybe<Scalars["String"]["input"]>;
+  p_file_type?: InputMaybe<Scalars["String"]["input"]>;
+  p_is_won?: InputMaybe<Scalars["Boolean"]["input"]>;
+  p_name_en?: InputMaybe<Scalars["String"]["input"]>;
+  p_name_jp?: InputMaybe<Scalars["String"]["input"]>;
+};
+
 /** mutation root */
 export type MutationRoot = {
   __typename?: "mutation_root";
+  /** execute VOLATILE function "create_prize_with_image" which returns "prizes" */
+  createPrizeWithImage: Array<Prizes>;
   /** execute VOLATILE function "decrement_latest_reach_log" which returns "reach_logs" */
   decrementLatestReachLog: Array<ReachLogs>;
   /** delete data from the table: "images" */
@@ -1400,6 +1413,16 @@ export type MutationRoot = {
   updateStampTriggers?: Maybe<StampTriggersMutationResponse>;
   /** update multiples rows of table: "stamp_triggers" */
   updateStampTriggersMany?: Maybe<Array<Maybe<StampTriggersMutationResponse>>>;
+};
+
+/** mutation root */
+export type MutationRootCreatePrizeWithImageArgs = {
+  args: CreatePrizeWithImageArgs;
+  distinctOn?: InputMaybe<Array<PrizesSelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<Array<PrizesOrderBy>>;
+  where?: InputMaybe<PrizesBoolExp>;
 };
 
 /** mutation root */
@@ -2023,6 +2046,29 @@ export type SubscribeListNumbersSubscription = {
   }>;
 };
 
+export type CreatePrizeWithImageMutationVariables = Exact<{
+  isWon: Scalars["Boolean"]["input"];
+  nameJp: Scalars["String"]["input"];
+  nameEn: Scalars["String"]["input"];
+  bucketName: Scalars["String"]["input"];
+  fileName: Scalars["String"]["input"];
+  fileType: Scalars["String"]["input"];
+}>;
+
+export type CreatePrizeWithImageMutation = {
+  __typename?: "mutation_root";
+  createPrizeWithImage: Array<{
+    __typename?: "Prizes";
+    id: number;
+    isWon: boolean;
+    imageId: number;
+    nameJp: string;
+    nameEn?: string | null;
+    createdAt: any;
+    updatedAt: any;
+  }>;
+};
+
 export type GetListPrizesQueryVariables = Exact<{ [key: string]: never }>;
 
 export type GetListPrizesQuery = {
@@ -2116,11 +2162,11 @@ export type GetOneLatestReachLogQuery = {
   reachLogs: Array<{ __typename?: "ReachLogs"; reachNum: number }>;
 };
 
-export type SubscribeOneLatestReachlogSubscriptionVariables = Exact<{
+export type SubscribeOneLatestReachLogSubscriptionVariables = Exact<{
   [key: string]: never;
 }>;
 
-export type SubscribeOneLatestReachlogSubscription = {
+export type SubscribeOneLatestReachLogSubscription = {
   __typename?: "subscription_root";
   reachLogs: Array<{ __typename?: "ReachLogs"; reachNum: number }>;
 };
@@ -2334,6 +2380,45 @@ export const SubscribeListNumbersDocument = gql`
 `;
 export type SubscribeListNumbersSubscriptionResult =
   Apollo.SubscriptionResult<SubscribeListNumbersSubscription>;
+export const CreatePrizeWithImageDocument = gql`
+  mutation CreatePrizeWithImage(
+    $isWon: Boolean!
+    $nameJp: String!
+    $nameEn: String!
+    $bucketName: String!
+    $fileName: String!
+    $fileType: String!
+  ) {
+    createPrizeWithImage(
+      args: {
+        p_is_won: $isWon
+        p_name_jp: $nameJp
+        p_name_en: $nameEn
+        p_bucket_name: $bucketName
+        p_file_name: $fileName
+        p_file_type: $fileType
+      }
+    ) {
+      id
+      isWon
+      imageId
+      nameJp
+      nameEn
+      createdAt
+      updatedAt
+    }
+  }
+`;
+export type CreatePrizeWithImageMutationFn = Apollo.MutationFunction<
+  CreatePrizeWithImageMutation,
+  CreatePrizeWithImageMutationVariables
+>;
+export type CreatePrizeWithImageMutationResult =
+  Apollo.MutationResult<CreatePrizeWithImageMutation>;
+export type CreatePrizeWithImageMutationOptions = Apollo.BaseMutationOptions<
+  CreatePrizeWithImageMutation,
+  CreatePrizeWithImageMutationVariables
+>;
 export const GetListPrizesDocument = gql`
   query GetListPrizes {
     prizes {
@@ -2451,15 +2536,15 @@ export type GetOneLatestReachLogQueryResult = Apollo.QueryResult<
   GetOneLatestReachLogQuery,
   GetOneLatestReachLogQueryVariables
 >;
-export const SubscribeOneLatestReachlogDocument = gql`
-  subscription SubscribeOneLatestReachlog {
+export const SubscribeOneLatestReachLogDocument = gql`
+  subscription SubscribeOneLatestReachLog {
     reachLogs(orderBy: { createdAt: DESC }, limit: 1) {
       reachNum
     }
   }
 `;
-export type SubscribeOneLatestReachlogSubscriptionResult =
-  Apollo.SubscriptionResult<SubscribeOneLatestReachlogSubscription>;
+export type SubscribeOneLatestReachLogSubscriptionResult =
+  Apollo.SubscriptionResult<SubscribeOneLatestReachLogSubscription>;
 export const GetListReachLogsAfterTimestampDocument = gql`
   query GetListReachLogsAfterTimestamp($timestamp: timestamptz!) {
     reachLogs(

--- a/view-user/src/types/graphql.ts
+++ b/view-user/src/types/graphql.ts
@@ -375,6 +375,8 @@ export type NumbersBoolExp = {
 
 /** unique or primary key constraints on table "numbers" */
 export enum NumbersConstraint {
+  /** unique or primary key constraint on columns "number" */
+  numbersNumberKey = "numbers_number_key",
   /** unique or primary key constraint on columns "id" */
   numbersPkey = "numbers_pkey",
 }
@@ -1327,9 +1329,20 @@ export type TimestamptzComparisonExp = {
   _nin?: InputMaybe<Array<Scalars["timestamptz"]["input"]>>;
 };
 
+export type CreatePrizeWithImageArgs = {
+  p_bucket_name?: InputMaybe<Scalars["String"]["input"]>;
+  p_file_name?: InputMaybe<Scalars["String"]["input"]>;
+  p_file_type?: InputMaybe<Scalars["String"]["input"]>;
+  p_is_won?: InputMaybe<Scalars["Boolean"]["input"]>;
+  p_name_en?: InputMaybe<Scalars["String"]["input"]>;
+  p_name_jp?: InputMaybe<Scalars["String"]["input"]>;
+};
+
 /** mutation root */
 export type MutationRoot = {
   __typename?: "mutation_root";
+  /** execute VOLATILE function "create_prize_with_image" which returns "prizes" */
+  createPrizeWithImage: Array<Prizes>;
   /** execute VOLATILE function "decrement_latest_reach_log" which returns "reach_logs" */
   decrementLatestReachLog: Array<ReachLogs>;
   /** delete data from the table: "images" */
@@ -1400,6 +1413,16 @@ export type MutationRoot = {
   updateStampTriggers?: Maybe<StampTriggersMutationResponse>;
   /** update multiples rows of table: "stamp_triggers" */
   updateStampTriggersMany?: Maybe<Array<Maybe<StampTriggersMutationResponse>>>;
+};
+
+/** mutation root */
+export type MutationRootCreatePrizeWithImageArgs = {
+  args: CreatePrizeWithImageArgs;
+  distinctOn?: InputMaybe<Array<PrizesSelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  orderBy?: InputMaybe<Array<PrizesOrderBy>>;
+  where?: InputMaybe<PrizesBoolExp>;
 };
 
 /** mutation root */


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->

# 対応Issue

<!-- 対応したIssue番号を記載 -->

- resolve #0
なし！

# 概要

<!-- 開発内容の概要を記載 -->
今までは
minioへ画像送信
insertImageを実行
insertPrizeを実行
としていたが
insert部分を一括で行うようにfunctionを作成した。
minio部分は修正不可な感じだったので放置

# 実装詳細

<!-- 具体的な開発内容を記載 -->
新たにcreate_prize_with_image functionを作成
ここでprize,imageを一括でpostするようにしている。
失敗時に何もデータが追加されないはず
pages/postPrizeのリファクタも行った。
カスタムフックだからuseEffectを使ってdata.prizesを格納するのは二度手間であるため修正した。

# 画面スクリーンショット等

<!-- URLとともに貼る（なければ空欄でよい） -->

# テスト項目

<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->

- [ ] 送信が正常に行われるか
- [ ] postPrize pageのデザインが崩れていないか
- [ ] コードレビュー

# 備考

<!-- 実装していて困った箇所・質問など -->
down -vしてください！
関数部分はgptとコネコネしてたから変かも