### PR TITLE
[fix] websocket load test scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,14 @@
     - `docker compose run --rm [コンテナ名] bash` でそのコンテナに入る
     - `chown +x -R .`　で実行権限を与える
     - `exit`でそのコンテナから出る
+
+## Load Testing
+
+WebSocket 通信の負荷計測には [Artillery](https://www.artillery.io/) を使用します。
+`loadtest/ws-loadtest.yml` では、Hasura で定義された `SubscribeListNumbers` サブスクリプションを利用したシナリオを記述しています。以下のコマンドで実行できます。
+
+```bash
+WS_API_URL=ws://localhost:8080 HASURA_GRAPHQL_ADMIN_SECRET=your_secret npx artillery run loadtest/ws-loadtest.yml
+```
+
+`WS_API_URL` と `HASURA_GRAPHQL_ADMIN_SECRET` は環境に合わせて設定してください。

--- a/loadtest/package.json
+++ b/loadtest/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "loadtest",
+  "private": true,
+  "scripts": {
+    "test": "npx artillery run ws-loadtest.yml"
+  },
+  "devDependencies": {
+    "artillery": "^2.0.0",
+    "graphql-ws": "^5.13.0",
+    "ws": "^8.13.0"
+  }
+}

--- a/loadtest/ws-loadtest.yml
+++ b/loadtest/ws-loadtest.yml
@@ -1,0 +1,21 @@
+config:
+  target: "{{ $processEnvironment.WS_API_URL }}/v1/graphql"
+  phases:
+    - duration: 60
+      arrivalRate: 10
+  engine: ws
+
+scenarios:
+  - name: "SubscribeListNumbers via WS"
+    flow:
+      - send:
+          text: |
+            {"type":"connection_init","payload":{"headers":{"x-hasura-admin-secret":"{{ $processEnvironment.HASURA_GRAPHQL_ADMIN_SECRET }}"}}}
+      - think: 1
+      - send:
+          text: |
+            {"id":"1","type":"subscribe","payload":{"query":"subscription SubscribeListNumbers { numbers { id number createdAt updatedAt } }","variables":{}}}
+      - think: 1
+      - send:
+          text: |
+            {"id":"1","type":"complete"}


### PR DESCRIPTION
## Summary
- use `SubscribeListNumbers` subscription in load test scenario
- clarify README instructions in Japanese

## Testing
- `npm run lint` in `view-user` *(fails: `next` not found)*
- `npm run lint` in `view-admin` *(fails: `next` not found)*
- `npm test` in `loadtest` *(fails: `npm ERR! 403 Forbidden` due to network restrictions)*


------
https://chatgpt.com/codex/tasks/task_e_684d07cd7d20832bb8ae4797a36d0c47