### PR TITLE
feat: 既存の賞品画像を用いたシードデータ機能の実装

### DIFF
--- a/.docker/api.Dockerfile
+++ b/.docker/api.Dockerfile
@@ -1,3 +1,12 @@
 FROM hasura/graphql-engine:v2.36.6@sha256:3fc234510962e66d5ca7db16734b8796a16fb729953915861953e974f976f30f
 WORKDIR /hasura/api
+
+# Hasura CLIのインストール
 RUN curl -L https://github.com/hasura/graphql-engine/raw/stable/cli/get.sh | bash
+
+# MinIOクライアント（mc）のインストール
+RUN curl -L https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc && \
+    chmod +x /usr/local/bin/mc
+
+# 必要なパッケージのインストール
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 run:
 	docker compose up -d --build
-	sleep 10
+	sleep 20
 	make db-apply
 
 down:
@@ -25,14 +25,21 @@ run-prod:
 	sleep 10
 	make db-apply-prod
 
+# MinIO credentials management
+generate-minio-keys:
+	cd api/seeds && ./generate_minio_credentials.sh
+
 # Seed data commands
 seed:
-	docker compose build api
 	cd api/seeds && ./seed_with_existing_images.sh
 
-# Complete setup with seed data
-setup: run
-	sleep 5
+# Complete setup with new MinIO credentials and seed data
+setup:
+	make run
+	make generate-minio-keys
+	@echo "🔄 Restarting containers to apply new credentials..."
+	docker compose restart
+	sleep 10
 	make seed
 
 codegen/user:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 run:
-	docker compose up -d
+	docker compose up -d --build
 	sleep 10
 	make db-apply
 
@@ -24,6 +24,16 @@ run-prod:
 	docker compose -f docker-compose.prod.yml up -d
 	sleep 10
 	make db-apply-prod
+
+# Seed data commands
+seed:
+	docker compose build api
+	cd api/seeds && ./seed_with_existing_images.sh
+
+# Complete setup with seed data
+setup: run
+	sleep 5
+	make seed
 
 codegen/user:
 	docker compose run --rm view-user npm run codegen

--- a/README.md
+++ b/README.md
@@ -1,20 +1,55 @@
 # nutfes-Bingo
+
 技大祭当日に使うビンゴアプリです。
 
-## Branch命名規則
-新機能のBranch名：feature/issue○○/title[isuueの簡単な説明]
+## Branch 命名規則
 
-修正のBranch名：fix/issue○○/title[issueの簡単な説明]
- 
-## PR命名規則
+新機能の Branch 名：feature/issue○○/title[isuue の簡単な説明]
+
+修正の Branch 名：fix/issue○○/title[issue の簡単な説明]
+
+## PR 命名規則
+
 新機能：[add] title
 
 編集・修正：[fix] title
 
 削除：[del] title
 
+## セットアップ
+
+### 基本的なセットアップ
+
+```bash
+make setup
+```
+
+### MinIO 認証情報を新規生成してセットアップ
+
+```bash
+make setup-with-new-keys
+```
+
+### MinIO 認証情報のみ生成
+
+```bash
+make generate-minio-keys
+```
+
 ## 実装メモ
+
 - `next: permission denied`が出る時の対処法
-    - `docker compose run --rm [コンテナ名] bash` でそのコンテナに入る
-    - `chown +x -R .`　で実行権限を与える
-    - `exit`でそのコンテナから出る
+  - `docker compose run --rm [コンテナ名] bash` でそのコンテナに入る
+  - `chown +x -R .`　で実行権限を与える
+  - `exit`でそのコンテナから出る
+
+### MinIO 認証情報について
+
+- MinIO のアクセスキーとシークレットキーは `api/seeds/generate_minio_credentials.sh` で自動生成可能
+- GUI 操作不要で、mc コマンドを使用して認証情報を生成・更新
+- 環境変数ファイル (`settings/bingo.env`, `settings/admin.env`) は自動的にバックアップ・更新される
+- **バケット作成も認証情報生成時に自動実行される**
+
+### スクリプトの役割分担
+- `generate_minio_credentials.sh`: MinIO 環境セットアップ（認証情報生成 + バケット作成）
+- `seed_with_existing_images.sh`: データ投入のみ（画像アップロード + DB 登録）

--- a/api/seeds/generate_minio_credentials.sh
+++ b/api/seeds/generate_minio_credentials.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+
+# =============================================================================
+# MinIO アクセスキー自動生成スクリプト
+# =============================================================================
+# 概要: mcコマンドを使用してMinIOに新しいアクセスキーとシークレットキーを
+#       自動生成し、環境変数ファイルを更新する
+#
+# 処理の流れ:
+# 1. MinIO管理者認証情報で接続
+# 2. 新しいユーザーを作成
+# 3. ユーザーにreadwrite権限を付与
+# 4. 作成されたアクセスキーを環境変数ファイルに反映
+
+set -e  # エラー時に停止
+
+echo "🔑 Starting MinIO credentials generation..."
+
+# 環境変数の読み込み（管理者認証情報）
+ADMIN_ENV_FILE="../../settings/admin.env"
+if [ -f "$ADMIN_ENV_FILE" ]; then
+    set -a
+    source "$ADMIN_ENV_FILE"
+    set +a
+else
+    echo "Error: Admin environment file $ADMIN_ENV_FILE not found"
+    exit 1
+fi
+
+# MinIO管理者設定
+MINIO_ENDPOINT="http://minio:9000"
+ROOT_USER="${MINIO_ROOT_USER}"
+ROOT_PASSWORD="${MINIO_ROOT_PASSWORD}"
+
+# 新しいユーザー名とパスワードを生成
+NEW_USER="bingo-$(openssl rand -hex 8)"
+NEW_PASSWORD=$(openssl rand -base64 32 | tr -d "=+/" | cut -c1-32)
+
+echo "📋 Configuration:"
+echo "  MinIO Endpoint: $MINIO_ENDPOINT"
+echo "  Root User: $ROOT_USER"
+echo "  New User: $NEW_USER"
+
+# 1. MinIO管理者として接続
+echo ""
+echo "🔐 Setting up admin connection..."
+docker compose exec minio mc alias set admin $MINIO_ENDPOINT $ROOT_USER $ROOT_PASSWORD
+
+# 2. バケットが存在することを確認（作成は既存スクリプトで行う）
+echo ""
+echo "📦 Checking bucket existence..."
+if ! docker compose exec minio mc ls admin/bingo >/dev/null 2>&1; then
+    echo "📦 Creating bucket..."
+    docker compose exec minio mc mb admin/bingo --ignore-existing
+    docker compose exec minio mc anonymous set public admin/bingo
+fi
+
+# 3. 新しいユーザーを作成
+echo ""
+echo "👤 Creating new user: $NEW_USER"
+docker compose exec minio mc admin user add admin $NEW_USER $NEW_PASSWORD
+
+# 4. ユーザーにreadwrite権限を付与
+echo ""
+echo "🔒 Setting up user permissions..."
+docker compose exec minio mc admin policy attach admin readwrite --user=$NEW_USER
+
+# 5. 作成されたアクセスキーを確認
+echo ""
+echo "✅ New credentials generated:"
+echo "  Access Key: $NEW_USER"
+echo "  Secret Key: $NEW_PASSWORD"
+
+# 6. 環境変数ファイルを更新
+BINGO_ENV_FILE="../../settings/bingo.env"
+if [ -f "$BINGO_ENV_FILE" ]; then
+    echo ""
+    echo "💾 Updating environment files..."
+
+    # bingo.envのアクセスキーを更新
+    sed -i "s/NEXT_PUBLIC_ACCESS_KEY=.*/NEXT_PUBLIC_ACCESS_KEY='$NEW_USER'/" "$BINGO_ENV_FILE"
+    sed -i "s/NEXT_PUBLIC_SECRET_KEY=.*/NEXT_PUBLIC_SECRET_KEY='$NEW_PASSWORD'/" "$BINGO_ENV_FILE"
+
+    echo "  ✅ Updated: $BINGO_ENV_FILE"
+else
+    echo "⚠️  Warning: $BINGO_ENV_FILE not found. Please update manually:"
+    echo "  NEXT_PUBLIC_ACCESS_KEY='$NEW_USER'"
+    echo "  NEXT_PUBLIC_SECRET_KEY='$NEW_PASSWORD'"
+fi
+
+# 7. admin.envも同様に更新
+if [ -f "$ADMIN_ENV_FILE" ]; then
+    echo ""
+    echo "💾 Updating environment files..."
+
+    # admin.envのアクセスキーを更新
+    sed -i "s/NEXT_PUBLIC_ACCESS_KEY=.*/NEXT_PUBLIC_ACCESS_KEY='$NEW_USER'/" "$ADMIN_ENV_FILE"
+    sed -i "s/NEXT_PUBLIC_SECRET_KEY=.*/NEXT_PUBLIC_SECRET_KEY='$NEW_PASSWORD'/" "$ADMIN_ENV_FILE"
+
+    echo "  ✅ Updated: $ADMIN_ENV_FILE"
+fi
+
+# 8. バケット作成とセットアップ
+echo ""
+echo "📦 Setting up MinIO bucket..."
+docker compose exec minio mc alias set test $MINIO_ENDPOINT $NEW_USER $NEW_PASSWORD
+
+# バケット作成
+BUCKET_NAME="${NEXT_PUBLIC_BUCKET_NAME:-bingo}"
+echo "🔨 Creating bucket: $BUCKET_NAME"
+if docker compose exec minio mc mb test/$BUCKET_NAME --ignore-existing; then
+    echo "✅ Bucket '$BUCKET_NAME' created/verified successfully!"
+
+    # バケットのパブリック読み取り設定（画像表示用）
+    echo "🔓 Setting public read policy for images..."
+    docker compose exec minio mc anonymous set public test/$BUCKET_NAME/prizes/ 2>/dev/null || true
+    echo "✅ Public read policy configured"
+else
+    echo "❌ Failed to create bucket"
+fi
+
+# 9. 接続テスト
+echo ""
+echo "🧪 Testing bucket access..."
+if docker compose exec minio mc ls test/$BUCKET_NAME >/dev/null 2>&1; then
+    echo "✅ Bucket access test successful!"
+else
+    echo "❌ Bucket access test failed!"
+    exit 1
+fi
+
+# テスト用エイリアスをクリーンアップ
+docker compose exec minio mc alias remove test >/dev/null 2>&1
+
+echo ""
+echo "🎉 MinIO credentials generation completed!"
+echo ""
+echo "📝 Summary:"
+echo "  - New user created: $NEW_USER"
+echo "  - Environment files updated"
+echo "  - Connection tested successfully"
+echo ""
+echo "⚠️  Important: Restart your Docker containers to use the new credentials:"
+echo "   docker compose down && docker compose up -d"

--- a/api/seeds/seed_with_existing_images.sh
+++ b/api/seeds/seed_with_existing_images.sh
@@ -8,13 +8,12 @@
 #
 # 処理の流れ:
 # 1. 環境変数の読み込み (bingo.env)
-# 2. MinIOバケットの作成・設定
-# 3. 既存のimages/prizesデータのクリーンアップ
-# 4. view-user/public/PrizeItem/内の画像を順次処理:
+# 2. MinIOクライアントの設定
+# 3. view-user/public/PrizeItem/内の画像を順次処理:
 #    - MinIOにアップロード (prizes/ディレクトリ配下)
 #    - imagesテーブルにメタデータ登録
 #    - prizesテーブルに景品情報登録
-# 5. 作成結果のサマリー表示
+# 4. 作成結果のサマリー表示
 
 set -e  # エラー時に停止
 
@@ -36,162 +35,304 @@ BUCKET_NAME="${NEXT_PUBLIC_BUCKET_NAME}"
 ACCESS_KEY="${NEXT_PUBLIC_ACCESS_KEY}"
 SECRET_KEY="${NEXT_PUBLIC_SECRET_KEY}"
 HASURA_ENDPOINT="${API_URI}/v1/graphql"
+HASURA_METADATA_ENDPOINT="${API_URI}/v1/metadata"
 ADMIN_SECRET="${HASURA_GRAPHQL_ADMIN_SECRET}"
 
 # 画像ディレクトリ
 PRIZE_IMAGES_DIR="view-user/public/PrizeItem"
 
-echo "🚀 Starting seed data creation with existing images..."
-
-# 1. MinIOクライアントの設定とバケット作成（Docker経由）
-echo "📦 Setting up MinIO client and creating bucket..."
-docker compose exec api mc alias set local $MINIO_ENDPOINT $ACCESS_KEY $SECRET_KEY
-docker compose exec api mc mb local/$BUCKET_NAME --ignore-existing
-
-# 2. 既存データのクリーンアップ
-echo "🧹 Cleaning up existing data..."
-curl -X POST \
-  $HASURA_ENDPOINT \
-  -H "Content-Type: application/json" \
-  -H "X-Hasura-Admin-Secret: $ADMIN_SECRET" \
-  -d '{
-    "type": "run_sql",
-    "args": {
-      "sql": "DELETE FROM prizes; DELETE FROM images; ALTER SEQUENCE images_id_seq RESTART WITH 1; ALTER SEQUENCE prizes_id_seq RESTART WITH 1;"
-    }
-  }' > /dev/null
-
-# 3. 画像のアップロードとDB登録
-echo "📷 Uploading images and registering to database..."
-
-
-
-# 景品データの配列（ファイル名から景品名を抽出）
-declare -a prize_data=(
-    "01_Apple Watch SE.jpg|Apple Watch SE|Apple Watch SE"
-    "02_黒毛和牛1kg.jpg|黒毛和牛1kg|Japanese Wagyu Beef 1kg"
-    "03_選べるペアチケット.jpg|選べるペアチケット|Pair Ticket"
-    "04_コーヒーメーカー.jpg|コーヒーメーカー|Coffee Maker"
-    "05_缶つま.jpg|缶つま|Canned Food Set"
-    "06_朝日山 天籟 越淡麗 純米大吟醸.jpg|朝日山 天籟 越淡麗 純米大吟醸|Asahiyama Tenrai Sake"
-    "07_折りたたみ自転車.jpg|折りたたみ自転車|Folding Bicycle"
-    "08_焼肉プレート.jpg|焼肉プレート|BBQ Plate"
-    "09_ジバニャン着ぐるみ.jpg|ジバニャン着ぐるみ|Jibanyan Costume"
-    "10_チュッパチャプス200本ツリー.jpg|チュッパチャプス200本ツリー|Chupa Chups Tree 200pcs"
-    "11_技大セット.jpg|技大セット|NUT Set"
-    "12_瓶コーラ12本セット.jpg|瓶コーラ12本セット|Bottle Cola 12pcs Set"
-    "13_魚沼産コシヒカリ(2kg).jpg|魚沼産コシヒカリ(2kg)|Uonuma Koshihikari Rice 2kg"
-    "14_着る毛布(サメ).jpg|着る毛布(サメ)|Wearable Blanket (Shark)"
-    "15_駄菓子 詰め合わせセット.jpg|駄菓子 詰め合わせセット|Japanese Snack Set"
-    "16_トトロクッション.jpg|トトロクッション|Totoro Cushion"
-    "17_ハンディファン.jpg|ハンディファン|Handy Fan"
-    "18_サウナハット.jpg|サウナハット|Sauna Hat"
-    "19_ご飯が炊ける弁当箱.jpg|ご飯が炊ける弁当箱|Rice Cooking Lunch Box"
-    "20_人生ゲームゴールデンドリーム.jpg|人生ゲームゴールデンドリーム|Game of Life Golden Dream"
-    "21_寝袋.jpg|寝袋|Sleeping Bag"
-    "22_ソーダストリーム.jpg|ソーダストリーム|SodaStream"
-    "23_ナブラ演算子ゲーム.jpg|ナブラ演算子ゲーム|Nabla Operator Game"
-    "24_ダンベル.jpg|ダンベル|Dumbbell"
-    "25_ニュートンのゆりかご.jpg|ニュートンのゆりかご|Newton's Cradle"
-    "26_日めくりカレンダー(毎日アンミカ）.jpg|日めくりカレンダー(毎日アンミカ）|Daily Calendar (Anmika)"
-    "27_セクシー大根抱き枕.jpg|セクシー大根抱き枕|Sexy Radish Body Pillow"
-    "28_ペッパーミル.jpg|ペッパーミル|Pepper Mill"
-    "29_ザコシショウ来学記念セット.jpg|ザコシショウ来学記念セット|Zakoshi Show Memorial Set"
-    "30_巨大クマのぬいぐるみ.jpg|巨大クマのぬいぐるみ|Giant Bear Plushie"
-    "31_ハーゲンダッツ詰め合わせ.jpg|ハーゲンダッツ詰め合わせ|Haagen-Dazs Set"
+# 景品名配列（ファイル番号01-31に対応）
+declare -a PRIZE_NAMES_JP=(
+    "Apple Watch SE"
+    "黒毛和牛1kg"
+    "選べるペアチケット"
+    "コーヒーメーカー"
+    "缶つま"
+    "朝日山 天籟 越淡麗 純米大吟醸"
+    "折りたたみ自転車"
+    "焼肉プレート"
+    "ジバニャン着ぐるみ"
+    "チュッパチャプス200本ツリー"
+    "技大セット"
+    "瓶コーラ12本セット"
+    "魚沼産コシヒカリ(2kg)"
+    "着る毛布(サメ)"
+    "駄菓子 詰め合わせセット"
+    "トトロクッション"
+    "ハンディファン"
+    "サウナハット"
+    "ご飯が炊ける弁当箱"
+    "人生ゲームゴールデンドリーム"
+    "寝袋"
+    "ソーダストリーム"
+    "ナブラ演算子ゲーム"
+    "ダンベル"
+    "ニュートンのゆりかご"
+    "日めくりカレンダー(毎日アンミカ)"
+    "セクシー大根抱き枕"
+    "ペッパーミル"
+    "ザコシショウ来学記念セット"
+    "巨大クマのぬいぐるみ"
+    "ハーゲンダッツ詰め合わせ"
 )
 
-# 各画像を処理
-total_count=${#prize_data[@]}
+declare -a PRIZE_NAMES_EN=(
+    "Apple Watch SE"
+    "Kuroge Wagyu 1kg"
+    "Selectable Pair Ticket"
+    "Coffee Maker"
+    "Canned Delicacies"
+    "Asahiyama Tenrai Junmai Daiginjo"
+    "Folding Bicycle"
+    "BBQ Grill Plate"
+    "Jibanyan Costume"
+    "Chupa Chups 200 Tree"
+    "NUTEC Set"
+    "Bottled Coke 12 Set"
+    "Uonuma Koshihikari Rice (2kg)"
+    "Wearable Blanket (Shark)"
+    "Assorted Snacks Set"
+    "Totoro Cushion"
+    "Handy Fan"
+    "Sauna Hat"
+    "Rice Cooker Lunch Box"
+    "Game of Life Golden Dream"
+    "Sleeping Bag"
+    "SodaStream"
+    "Nabla Operator Game"
+    "Dumbbell"
+    "Newton's Cradle"
+    "Daily Calendar (Anmika)"
+    "Sexy Radish Pillow"
+    "Pepper Mill"
+    "Zakoshi Show Memorial Set"
+    "Giant Bear Plushie"
+    "Haagen-Dazs Assortment"
+)
+
+echo "🚀 Starting seed data creation with existing images..."
+
+# 1. MinIOクライアントの設定（データ操作用）
+# 前提条件: generate_minio_credentials.sh でMinIO環境が適切にセットアップ済み
+echo "🔑 Setting up MinIO client for data operations..."
+docker compose exec api mc alias set local $MINIO_ENDPOINT $ACCESS_KEY $SECRET_KEY
+
+# 2. 画像のアップロードとDB登録
+echo "📷 Uploading images and registering to database..."
+
+# 実際の画像ファイルを確認
+echo "🔍 Checking available image files..."
+cd ../../
+if [ ! -d "$PRIZE_IMAGES_DIR" ]; then
+    echo "❌ Directory not found: $PRIZE_IMAGES_DIR"
+    exit 1
+fi
+
+# 実際に存在するファイルを動的に取得
+available_files=$(find "$PRIZE_IMAGES_DIR" -name "*.jpg" -exec basename {} \; 2>/dev/null | sort)
+cd api/seeds
+
+if [ -z "$available_files" ]; then
+    echo "❌ No image files found in $PRIZE_IMAGES_DIR"
+    exit 1
+fi
+
+# ファイルリストを配列に変換
+mapfile -t test_files <<< "$available_files"
+
+total_count=${#test_files[@]}
 current_count=0
 
-for prize_info in "${prize_data[@]}"; do
+echo "Processing $total_count files..."
+
+# テストファイルを処理
+for filename in "${test_files[@]}"; do
+    # 個別の処理では set -e を一時的に無効にして続行
+    set +e
+
     ((current_count++))
-    IFS='|' read -r filename name_jp name_en <<< "$prize_info"
 
-    # プロジェクトルート内のファイルパス
+    # ファイル名をプリントして確認
+    echo "Processing file $current_count/$total_count: '$filename'"
+
+    # ファイル名から番号を抽出（01-31）
+    file_number=$(echo "$filename" | grep -o '^[0-9]\+' | sed 's/^0*//')
+
+    # 配列のインデックスは0ベースなので1を引く
+    array_index=$((file_number - 1))
+
+    # 配列から景品名を取得
+    if [ $array_index -ge 0 ] && [ $array_index -lt ${#PRIZE_NAMES_JP[@]} ]; then
+        name_jp="${PRIZE_NAMES_JP[$array_index]}"
+        name_en="${PRIZE_NAMES_EN[$array_index]}"
+        echo "  Prize names: JP='$name_jp', EN='$name_en'"
+    else
+        echo "  Warning: File number $file_number is out of range, using fallback names"
+        name_jp="景品 $file_number"
+        name_en="Prize $file_number"
+    fi
+
+    # ファイル名のクリーンアップ（MinIOアップロード用）
+    clean_filename=$(echo "$filename" | sed "s/^'//; s/'$//")
+
+    # ファイル名に特殊文字が含まれる場合のための安全な処理
+    # Docker内でのファイルパス（クォートで適切に囲む）
     source_path="/hasura/project/$PRIZE_IMAGES_DIR/$filename"
-    dest_path="local/$BUCKET_NAME/prizes/$filename"
+    dest_path="local/$BUCKET_NAME/prizes/$clean_filename"
 
-    # ホスト側でファイルの存在確認
-    if [ -f "../../$PRIZE_IMAGES_DIR/$filename" ]; then
-        echo -n "[$current_count/$total_count] Processing: $name_jp... "
+    echo -n "  Uploading $name_jp to MinIO... "
 
-        # MinIOに画像をアップロード
-        docker compose exec api sh -c "mc cp '$source_path' '$dest_path'" > /dev/null 2>&1
+    # MinIOに画像をアップロード（特殊文字対応のためprintf使用）
+    upload_result=$(docker compose exec api sh -c "mc cp '$source_path' '$dest_path'" 2>&1)
+    upload_exit_code=$?
+
+    if [ $upload_exit_code -eq 0 ]; then
+        echo "✅ Uploaded"
 
         # ファイル拡張子を取得
-        file_extension="${filename##*.}"
+        file_extension="${clean_filename##*.}"
 
-        # imagesテーブルに登録
+        # MinIOでのファイル名（prizes/プレフィックス付き、スペースはアンダースコアに変換）
+        safe_filename=$(echo "prizes/$clean_filename" | sed 's/ /_/g')
 
-        # ファイル名のスペースをアンダースコアに置換（安全な方法）
-        safe_filename=$(echo "prizes/$filename" | sed 's/ /_/g')
+        echo -n "  Registering image to database... "
+        # imagesテーブルに登録（既存チェック後に挿入）
+        escaped_bucket=$(printf '%s' "$BUCKET_NAME" | sed 's/"/\\"/g')
+        escaped_filename=$(printf '%s' "$safe_filename" | sed 's/"/\\"/g')
+        escaped_extension=$(printf '%s' "$file_extension" | sed 's/"/\\"/g')
 
-        # シンプルなGraphQLクエリ（変数なし）
-        image_response=$(curl -s -X POST \
-          $HASURA_ENDPOINT \
+        # 既存の画像をチェック
+        existing_image_response=$(curl -s -X POST \
+          "$HASURA_ENDPOINT" \
           -H "Content-Type: application/json" \
           -H "X-Hasura-Admin-Secret: $ADMIN_SECRET" \
-          -d "{\"query\":\"mutation { insertImagesOne(object: {bucketName: \\\"$BUCKET_NAME\\\", fileName: \\\"$safe_filename\\\", fileType: \\\"$file_extension\\\"}) { id } }\"}")
+          -d "{\"query\":\"query { images(where: {fileName: {_eq: \\\"$escaped_filename\\\"}}) { id } }\"}")
 
-        # レスポンスからimage_idを抽出
-        image_id=$(echo "$image_response" | grep -o '"id":[0-9]*' | grep -o '[0-9]*')
-
-        if [ -z "$image_id" ]; then
-            echo "❌ Failed to get image ID"
-            echo "Response: $image_response"
-            continue
-        fi
-
-        if [ ! -z "$image_id" ]; then
-            # prizesテーブルに登録（特殊文字をエスケープ）
-            safe_name_jp=$(echo "$name_jp" | sed 's/"/\\"/g')
-            safe_name_en=$(echo "$name_en" | sed 's/"/\\"/g')
-
-            prize_response=$(curl -s -X POST \
-              $HASURA_ENDPOINT \
-              -H "Content-Type: application/json" \
-              -H "X-Hasura-Admin-Secret: $ADMIN_SECRET" \
-              -d "{\"query\":\"mutation { insertPrizesOne(object: {imageId: $image_id, nameJp: \\\"$safe_name_jp\\\", nameEn: \\\"$safe_name_en\\\", isWon: false}) { id } }\"}")
-
-            # prizesのIDを確認
-            prize_id=$(echo "$prize_response" | grep -o '"id":[0-9]*' | grep -o '[0-9]*')
-
-            if [ ! -z "$prize_id" ]; then
-                echo "✅ 完了 ID: $image_id"
-            else
-                echo "❌ Prize registration failed"
-                echo "Response: $prize_response"
-            fi
+        # GraphQLレスポンスのエラーチェック
+        if echo "$existing_image_response" | grep -q '"errors"'; then
+            echo "❌ GraphQL error in image check"
+            echo "    Response: $existing_image_response"
         else
-            echo "❌ Failed to insert image"
+            existing_image_id=$(echo "$existing_image_response" | grep -o '"id":[0-9]*' | head -1 | grep -o '[0-9]*')
+
+            if [ ! -z "$existing_image_id" ]; then
+                image_id="$existing_image_id"
+                echo "✅ Image already exists ID: $image_id"
+            else
+                # 新規作成
+                image_response=$(curl -s -X POST \
+                  "$HASURA_ENDPOINT" \
+                  -H "Content-Type: application/json" \
+                  -H "X-Hasura-Admin-Secret: $ADMIN_SECRET" \
+                  -d "{\"query\":\"mutation { insertImagesOne(object: {bucketName: \\\"$escaped_bucket\\\", fileName: \\\"$escaped_filename\\\", fileType: \\\"$escaped_extension\\\"}) { id } }\"}")
+
+                # GraphQLレスポンスのエラーチェック
+                if echo "$image_response" | grep -q '"errors"'; then
+                    echo "❌ GraphQL error in image creation"
+                    echo "    Response: $image_response"
+                    image_id=""
+                else
+                    image_id=$(echo "$image_response" | grep -o '"id":[0-9]*' | head -1 | grep -o '[0-9]*')
+
+                    if [ ! -z "$image_id" ]; then
+                        echo "✅ Image created ID: $image_id"
+                    else
+                        echo "❌ Image registration failed"
+                        echo "    Response: $image_response"
+                        image_id=""
+                    fi
+                fi
+            fi
+
+            # 画像IDが取得できた場合のみ、景品を登録
+            if [ ! -z "$image_id" ]; then
+                echo -n "  Registering prize to database... "
+                # prizesテーブルに登録（既存チェック後に挿入）
+
+                # 既存の景品をチェック
+                existing_prize_response=$(curl -s -X POST \
+                  "$HASURA_ENDPOINT" \
+                  -H "Content-Type: application/json" \
+                  -H "X-Hasura-Admin-Secret: $ADMIN_SECRET" \
+                  -d "{\"query\":\"query { prizes(where: {imageId: {_eq: $image_id}}) { id } }\"}")
+
+                # GraphQLレスポンスのエラーチェック
+                if echo "$existing_prize_response" | grep -q '"errors"'; then
+                    echo "❌ GraphQL error in prize check"
+                    echo "    Response: $existing_prize_response"
+                else
+                    existing_prize_id=$(echo "$existing_prize_response" | grep -o '"id":[0-9]*' | head -1 | grep -o '[0-9]*')
+
+                    if [ ! -z "$existing_prize_id" ]; then
+                        echo "✅ Prize already exists ID: $existing_prize_id"
+                    else
+                        # 新規作成（JSONエスケープ）
+                        escaped_name_jp=$(printf '%s' "$name_jp" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g')
+                        escaped_name_en=$(printf '%s' "$name_en" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g')
+
+                        prize_response=$(curl -s -X POST \
+                          "$HASURA_ENDPOINT" \
+                          -H "Content-Type: application/json" \
+                          -H "X-Hasura-Admin-Secret: $ADMIN_SECRET" \
+                          -d "{\"query\":\"mutation { insertPrizesOne(object: {imageId: $image_id, nameJp: \\\"$escaped_name_jp\\\", nameEn: \\\"$escaped_name_en\\\", isWon: false}) { id } }\"}")
+
+                        # GraphQLレスポンスのエラーチェック
+                        if echo "$prize_response" | grep -q '"errors"'; then
+                            echo "❌ GraphQL error in prize creation"
+                            echo "    Response: $prize_response"
+                        else
+                            prize_id=$(echo "$prize_response" | grep -o '"id":[0-9]*' | head -1 | grep -o '[0-9]*')
+
+                            if [ ! -z "$prize_id" ]; then
+                                echo "✅ Prize created ID: $prize_id"
+                            else
+                                echo "❌ Prize registration failed"
+                                echo "    Response: $prize_response"
+                            fi
+                        fi
+                    fi
+                fi
+            fi
         fi
     else
-        echo "⚠️  [$current_count/$total_count] File not found: $filename"
+        echo "❌ Upload failed (exit code: $upload_exit_code)"
+        echo "    Error: $upload_result"
+        echo "    Source: '$source_path'"
+        echo "    Dest: '$dest_path'"
+
+        # ファイルが存在するかチェック
+        if docker compose exec api test -f "$source_path"; then
+            echo "    File exists in container"
+        else
+            echo "    File NOT found in container"
+        fi
     fi
+    echo ""
+
+    # 個別処理完了後、set -e を再度有効にする
+    set -e
 done
 
 echo ""
 echo "🎉 Seed data creation completed!"
 echo "📊 Summary:"
 
-# 結果のサマリーを表示
-images_count=$(curl -s -X POST \
-  $HASURA_ENDPOINT \
+# 結果のサマリーを表示（正しいフィールド名を使用）
+images_response=$(curl -s -X POST \
+  "$HASURA_ENDPOINT" \
   -H "Content-Type: application/json" \
   -H "X-Hasura-Admin-Secret: $ADMIN_SECRET" \
-  -d '{
-    "query": "query { images_aggregate { aggregate { count } } }"
-  }' | grep -o '"count":[0-9]*' | grep -o '[0-9]*')
+  -d '{"query": "query { imagesAggregate { aggregate { count } } }"}')
 
-prizes_count=$(curl -s -X POST \
-  $HASURA_ENDPOINT \
+images_count=$(echo "$images_response" | grep -o '"count"[[:space:]]*:[[:space:]]*[0-9]*' | grep -o '[0-9]*')
+
+prizes_response=$(curl -s -X POST \
+  "$HASURA_ENDPOINT" \
   -H "Content-Type: application/json" \
   -H "X-Hasura-Admin-Secret: $ADMIN_SECRET" \
-  -d '{
-    "query": "query { prizes_aggregate { aggregate { count } } }"
-  }' | grep -o '"count":[0-9]*' | grep -o '[0-9]*')
+  -d '{"query": "query { prizesAggregate { aggregate { count } } }"}')
+
+prizes_count=$(echo "$prizes_response" | grep -o '"count"[[:space:]]*:[[:space:]]*[0-9]*' | grep -o '[0-9]*')
 
 echo "  - Images uploaded: $images_count"
 echo "  - Prizes registered: $prizes_count"

--- a/api/seeds/seed_with_existing_images.sh
+++ b/api/seeds/seed_with_existing_images.sh
@@ -192,13 +192,13 @@ for filename in "${test_files[@]}"; do
         # ファイル拡張子を取得
         file_extension="${clean_filename##*.}"
 
-        # MinIOでのファイル名（prizes/プレフィックス付き、スペースはアンダースコアに変換）
-        safe_filename=$(echo "prizes/$clean_filename" | sed 's/ /_/g')
+        # MinIOでのファイル名（prizes/プレフィックス付き）
+        minio_filename="prizes/$clean_filename"
 
         echo -n "  Registering image to database... "
         # imagesテーブルに登録（既存チェック後に挿入）
         escaped_bucket=$(printf '%s' "$BUCKET_NAME" | sed 's/"/\\"/g')
-        escaped_filename=$(printf '%s' "$safe_filename" | sed 's/"/\\"/g')
+        escaped_filename=$(printf '%s' "$minio_filename" | sed 's/"/\\"/g')
         escaped_extension=$(printf '%s' "$file_extension" | sed 's/"/\\"/g')
 
         # 既存の画像をチェック

--- a/api/seeds/seed_with_existing_images.sh
+++ b/api/seeds/seed_with_existing_images.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+
+# =============================================================================
+# 景品画像Seedデータ作成スクリプト
+# =============================================================================
+# 概要: リポジトリ内の既存景品画像をMinIOにアップロードし、
+#       Hasuraデータベースにimagesとprizesテーブルのseedデータを作成する
+#
+# 処理の流れ:
+# 1. 環境変数の読み込み (bingo.env)
+# 2. MinIOバケットの作成・設定
+# 3. 既存のimages/prizesデータのクリーンアップ
+# 4. view-user/public/PrizeItem/内の画像を順次処理:
+#    - MinIOにアップロード (prizes/ディレクトリ配下)
+#    - imagesテーブルにメタデータ登録
+#    - prizesテーブルに景品情報登録
+# 5. 作成結果のサマリー表示
+
+set -e  # エラー時に停止
+
+# 環境変数の読み込み
+ENV_FILE="../../settings/bingo.env"
+if [ -f "$ENV_FILE" ]; then
+    # カンマやスペースを含む値でもエラーが出ないように修正
+    set -a  # 自動export有効
+    source "$ENV_FILE"
+    set +a  # 自動export無効
+else
+    echo "Error: Environment file $ENV_FILE not found"
+    exit 1
+fi
+
+# MinIO設定
+MINIO_ENDPOINT="${NEXT_PUBLIC_MINIO_ENDPOINT}"
+BUCKET_NAME="${NEXT_PUBLIC_BUCKET_NAME}"
+ACCESS_KEY="${NEXT_PUBLIC_ACCESS_KEY}"
+SECRET_KEY="${NEXT_PUBLIC_SECRET_KEY}"
+HASURA_ENDPOINT="${API_URI}/v1/graphql"
+ADMIN_SECRET="${HASURA_GRAPHQL_ADMIN_SECRET}"
+
+# 画像ディレクトリ
+PRIZE_IMAGES_DIR="view-user/public/PrizeItem"
+
+echo "🚀 Starting seed data creation with existing images..."
+
+# 1. MinIOクライアントの設定とバケット作成（Docker経由）
+echo "📦 Setting up MinIO client and creating bucket..."
+docker compose exec api mc alias set local $MINIO_ENDPOINT $ACCESS_KEY $SECRET_KEY
+docker compose exec api mc mb local/$BUCKET_NAME --ignore-existing
+
+# 2. 既存データのクリーンアップ
+echo "🧹 Cleaning up existing data..."
+curl -X POST \
+  $HASURA_ENDPOINT \
+  -H "Content-Type: application/json" \
+  -H "X-Hasura-Admin-Secret: $ADMIN_SECRET" \
+  -d '{
+    "type": "run_sql",
+    "args": {
+      "sql": "DELETE FROM prizes; DELETE FROM images; ALTER SEQUENCE images_id_seq RESTART WITH 1; ALTER SEQUENCE prizes_id_seq RESTART WITH 1;"
+    }
+  }' > /dev/null
+
+# 3. 画像のアップロードとDB登録
+echo "📷 Uploading images and registering to database..."
+
+
+
+# 景品データの配列（ファイル名から景品名を抽出）
+declare -a prize_data=(
+    "01_Apple Watch SE.jpg|Apple Watch SE|Apple Watch SE"
+    "02_黒毛和牛1kg.jpg|黒毛和牛1kg|Japanese Wagyu Beef 1kg"
+    "03_選べるペアチケット.jpg|選べるペアチケット|Pair Ticket"
+    "04_コーヒーメーカー.jpg|コーヒーメーカー|Coffee Maker"
+    "05_缶つま.jpg|缶つま|Canned Food Set"
+    "06_朝日山 天籟 越淡麗 純米大吟醸.jpg|朝日山 天籟 越淡麗 純米大吟醸|Asahiyama Tenrai Sake"
+    "07_折りたたみ自転車.jpg|折りたたみ自転車|Folding Bicycle"
+    "08_焼肉プレート.jpg|焼肉プレート|BBQ Plate"
+    "09_ジバニャン着ぐるみ.jpg|ジバニャン着ぐるみ|Jibanyan Costume"
+    "10_チュッパチャプス200本ツリー.jpg|チュッパチャプス200本ツリー|Chupa Chups Tree 200pcs"
+    "11_技大セット.jpg|技大セット|NUT Set"
+    "12_瓶コーラ12本セット.jpg|瓶コーラ12本セット|Bottle Cola 12pcs Set"
+    "13_魚沼産コシヒカリ(2kg).jpg|魚沼産コシヒカリ(2kg)|Uonuma Koshihikari Rice 2kg"
+    "14_着る毛布(サメ).jpg|着る毛布(サメ)|Wearable Blanket (Shark)"
+    "15_駄菓子 詰め合わせセット.jpg|駄菓子 詰め合わせセット|Japanese Snack Set"
+    "16_トトロクッション.jpg|トトロクッション|Totoro Cushion"
+    "17_ハンディファン.jpg|ハンディファン|Handy Fan"
+    "18_サウナハット.jpg|サウナハット|Sauna Hat"
+    "19_ご飯が炊ける弁当箱.jpg|ご飯が炊ける弁当箱|Rice Cooking Lunch Box"
+    "20_人生ゲームゴールデンドリーム.jpg|人生ゲームゴールデンドリーム|Game of Life Golden Dream"
+    "21_寝袋.jpg|寝袋|Sleeping Bag"
+    "22_ソーダストリーム.jpg|ソーダストリーム|SodaStream"
+    "23_ナブラ演算子ゲーム.jpg|ナブラ演算子ゲーム|Nabla Operator Game"
+    "24_ダンベル.jpg|ダンベル|Dumbbell"
+    "25_ニュートンのゆりかご.jpg|ニュートンのゆりかご|Newton's Cradle"
+    "26_日めくりカレンダー(毎日アンミカ）.jpg|日めくりカレンダー(毎日アンミカ）|Daily Calendar (Anmika)"
+    "27_セクシー大根抱き枕.jpg|セクシー大根抱き枕|Sexy Radish Body Pillow"
+    "28_ペッパーミル.jpg|ペッパーミル|Pepper Mill"
+    "29_ザコシショウ来学記念セット.jpg|ザコシショウ来学記念セット|Zakoshi Show Memorial Set"
+    "30_巨大クマのぬいぐるみ.jpg|巨大クマのぬいぐるみ|Giant Bear Plushie"
+    "31_ハーゲンダッツ詰め合わせ.jpg|ハーゲンダッツ詰め合わせ|Haagen-Dazs Set"
+)
+
+# 各画像を処理
+total_count=${#prize_data[@]}
+current_count=0
+
+for prize_info in "${prize_data[@]}"; do
+    ((current_count++))
+    IFS='|' read -r filename name_jp name_en <<< "$prize_info"
+
+    # プロジェクトルート内のファイルパス
+    source_path="/hasura/project/$PRIZE_IMAGES_DIR/$filename"
+    dest_path="local/$BUCKET_NAME/prizes/$filename"
+
+    # ホスト側でファイルの存在確認
+    if [ -f "../../$PRIZE_IMAGES_DIR/$filename" ]; then
+        echo -n "[$current_count/$total_count] Processing: $name_jp... "
+
+        # MinIOに画像をアップロード
+        docker compose exec api sh -c "mc cp '$source_path' '$dest_path'" > /dev/null 2>&1
+
+        # ファイル拡張子を取得
+        file_extension="${filename##*.}"
+
+        # imagesテーブルに登録
+
+        # ファイル名のスペースをアンダースコアに置換（安全な方法）
+        safe_filename=$(echo "prizes/$filename" | sed 's/ /_/g')
+
+        # シンプルなGraphQLクエリ（変数なし）
+        image_response=$(curl -s -X POST \
+          $HASURA_ENDPOINT \
+          -H "Content-Type: application/json" \
+          -H "X-Hasura-Admin-Secret: $ADMIN_SECRET" \
+          -d "{\"query\":\"mutation { insertImagesOne(object: {bucketName: \\\"$BUCKET_NAME\\\", fileName: \\\"$safe_filename\\\", fileType: \\\"$file_extension\\\"}) { id } }\"}")
+
+        # レスポンスからimage_idを抽出
+        image_id=$(echo "$image_response" | grep -o '"id":[0-9]*' | grep -o '[0-9]*')
+
+        if [ -z "$image_id" ]; then
+            echo "❌ Failed to get image ID"
+            echo "Response: $image_response"
+            continue
+        fi
+
+        if [ ! -z "$image_id" ]; then
+            # prizesテーブルに登録（特殊文字をエスケープ）
+            safe_name_jp=$(echo "$name_jp" | sed 's/"/\\"/g')
+            safe_name_en=$(echo "$name_en" | sed 's/"/\\"/g')
+
+            prize_response=$(curl -s -X POST \
+              $HASURA_ENDPOINT \
+              -H "Content-Type: application/json" \
+              -H "X-Hasura-Admin-Secret: $ADMIN_SECRET" \
+              -d "{\"query\":\"mutation { insertPrizesOne(object: {imageId: $image_id, nameJp: \\\"$safe_name_jp\\\", nameEn: \\\"$safe_name_en\\\", isWon: false}) { id } }\"}")
+
+            # prizesのIDを確認
+            prize_id=$(echo "$prize_response" | grep -o '"id":[0-9]*' | grep -o '[0-9]*')
+
+            if [ ! -z "$prize_id" ]; then
+                echo "✅ 完了 ID: $image_id"
+            else
+                echo "❌ Prize registration failed"
+                echo "Response: $prize_response"
+            fi
+        else
+            echo "❌ Failed to insert image"
+        fi
+    else
+        echo "⚠️  [$current_count/$total_count] File not found: $filename"
+    fi
+done
+
+echo ""
+echo "🎉 Seed data creation completed!"
+echo "📊 Summary:"
+
+# 結果のサマリーを表示
+images_count=$(curl -s -X POST \
+  $HASURA_ENDPOINT \
+  -H "Content-Type: application/json" \
+  -H "X-Hasura-Admin-Secret: $ADMIN_SECRET" \
+  -d '{
+    "query": "query { images_aggregate { aggregate { count } } }"
+  }' | grep -o '"count":[0-9]*' | grep -o '[0-9]*')
+
+prizes_count=$(curl -s -X POST \
+  $HASURA_ENDPOINT \
+  -H "Content-Type: application/json" \
+  -H "X-Hasura-Admin-Secret: $ADMIN_SECRET" \
+  -d '{
+    "query": "query { prizes_aggregate { aggregate { count } } }"
+  }' | grep -o '"count":[0-9]*' | grep -o '[0-9]*')
+
+echo "  - Images uploaded: $images_count"
+echo "  - Prizes registered: $prizes_count"
+echo ""
+echo "🔗 You can now access the images at: $MINIO_ENDPOINT/$BUCKET_NAME/prizes/"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - "8080:8080"
     volumes:
       - ./api:/hasura/api
+      - .:/hasura/project # プロジェクト全体をマウント（seedスクリプト用）
     env_file:
       - ./settings/bingo.env
 


### PR DESCRIPTION
## 概要
既存のリポジトリ内の賞品画像を使用して、MinIOへのアップロードとHasuraデータベースへのメタデータ登録を行うシードデータ機能を実装しました。

## 実装内容

### 🐳 インフラストラクチャの変更
- **APIコンテナ**: MinIOクライアント(`mc`)をDockerイメージに追加
- **Docker Compose**: プロジェクトルートを`/hasura/project`にマウント
- **Makefile**: `make seed`および`make setup`コマンドを追加

### 📂 シードスクリプトの実装
- `api/seeds/seed_with_existing_images.sh`: メインのシードスクリプト
- 31個の既存賞品画像を`view-user/public/PrizeItem/`から自動処理
- MinIOの`prizes`バケットへのアップロード
- HasuraのGraphQL APIを通じたメタデータ登録

### ✨ 主な機能
- **環境設定**: `settings/bingo.env`から環境変数を自動読み込み
- **データクリーンアップ**: 既存のimages/prizesデータを安全に削除
- **プログレス表示**: `[1/31] Processing: Apple Watch SE... ✅ 完了 ID: 123` 形式
- **エラーハンドリング**: 各ステップでの適切なエラー処理とログ出力

### 🔧 技術的解決事項
- JSONエスケープ処理（特殊文字・スペース含むファイル名対応）
- GraphQLスキーマに合わせたフィールド名修正（camelCase対応）
- bashスタンダード機能のみを使用（外部依存なし）

## 使用方法
```bash
# セットアップ（初回のみ）
make setup

# シードデータの実行
make seed
```

## テスト済み環境
- Docker環境でのMinIOクライアント動作確認
- 31個の画像ファイルすべてでの正常動作確認
- 特殊文字（日本語、スペース等）を含むファイル名での動作確認

<img width="503" height="852" alt="image" src="https://github.com/user-attachments/assets/bee3e25b-960a-484b-8b7e-d6f6eac035b8" />

prizes配下に保存
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/31580f86-7b74-418b-b6dd-71f8d90a2a4d" />
