### PR TITLE
[user] 景品ページのsettingsでとグルボタンが押せない問題の解消

### DIFF
--- a/view-user/src/components/Layout/Layout.tsx
+++ b/view-user/src/components/Layout/Layout.tsx
@@ -1,6 +1,6 @@
 import { useLazyQuery, useMutation, useSubscription } from "@apollo/client";
 import { useState, useRef, useLayoutEffect, useEffect } from "react";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
 import { hasShownSurveyState } from "@/state/survey";
 import { useRouter } from "next/router";
 import styles from "./Layout.module.css";
@@ -33,6 +33,7 @@ import type {
   GetOneLatestReachLogQuery,
 } from "@/types/graphql";
 import { ja, en } from "@/locales";
+import { languageState } from "@/state/language";
 import { TwitterPicker } from "react-color";
 import { useSurveyState } from "@/hooks/useSurveyState";
 
@@ -81,13 +82,12 @@ interface LayoutProps {
   pageName: string;
   isSortedAscending?: boolean;
   setIsSortedAscending?: (value: boolean) => void;
-  language?: string;
-  setLanguage?: (value: string) => void;
 }
 
 const Layout = (props: LayoutProps) => {
   const router = useRouter();
-  const t = props.language === "ja" ? ja : en;
+  const language = useRecoilValue(languageState);
+  const t = language === "ja" ? ja : en;
 
   const [isReactionModalOpen, setIsReactionModalOpen] =
     useState<boolean>(false);
@@ -144,12 +144,12 @@ const Layout = (props: LayoutProps) => {
     const storedSortOrder = localStorage.getItem("isSortedAscending");
     if (storedSortOrder !== null) {
       const isSortedAscending = storedSortOrder === "true";
-      props.setIsSortedAscending?.(isSortedAscending);
+      setIsSortedAscending?.(isSortedAscending);
       setIsSortOrderActive(isSortedAscending);
     } else {
       localStorage.setItem("isSortedAscending", "false");
     }
-  }, []);
+  }, [setIsSortedAscending]);
 
   // 初期設定を適用
   useEffect(() => {
@@ -210,7 +210,7 @@ const Layout = (props: LayoutProps) => {
   };
 
   const toggleLanguage = () => {
-    const newLocale = props.language === "ja" ? "en" : "ja";
+    const newLocale = language === "ja" ? "en" : "ja";
     router.push(router.pathname, router.asPath, { locale: newLocale });
   };
 
@@ -297,10 +297,7 @@ const Layout = (props: LayoutProps) => {
           )}
           <div>
             <p>{t.settingsModal.languageSelection}</p>
-            <ToggleButton
-              isActive={props.language !== "ja"}
-              onClick={toggleLanguage}
-            >
+            <ToggleButton isActive={language !== "ja"} onClick={toggleLanguage}>
               <span>{t.settingsModal.japanese}</span>
               <span>{t.settingsModal.english}</span>
             </ToggleButton>

--- a/view-user/src/components/common/Modal/Modal.module.css
+++ b/view-user/src/components/common/Modal/Modal.module.css
@@ -12,6 +12,7 @@
 }
 
 .content {
+  position: relative;
   min-width: 87.5vw;
   min-height: 58.1vw;
   max-height: 70vh;

--- a/view-user/src/components/common/icons/BackIcon/BackIcon.tsx
+++ b/view-user/src/components/common/icons/BackIcon/BackIcon.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { IconFramework } from "@/components/common";
 import { TiArrowBack } from "react-icons/ti";
 import { useRouter } from "next/router";
+import { useRecoilValue } from "recoil";
+import { languageState } from "@/state/language";
 
 interface BackIconProps {
   id?: string;
@@ -9,10 +11,11 @@ interface BackIconProps {
 
 const BackIcon = (props: BackIconProps) => {
   const router = useRouter();
+  const language = useRecoilValue(languageState);
 
   const handleClick = () => {
     if (typeof window !== "undefined") {
-      router.back();
+      router.push("/", "/", { locale: language });
     }
   };
 

--- a/view-user/src/pages/_app.tsx
+++ b/view-user/src/pages/_app.tsx
@@ -1,10 +1,13 @@
 import "@/styles/reset.css";
 import "@/styles/globals.css";
 import type { AppProps } from "next/app";
+import { useEffect } from "react";
+import { useRouter } from "next/router";
 import { ApolloProvider, ApolloClient, InMemoryCache } from "@apollo/client";
 import { createClient } from "graphql-ws";
 import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
-import { RecoilRoot } from "recoil";
+import { RecoilRoot, useSetRecoilState } from "recoil";
+import { languageState } from "@/state/language";
 import localFont from "next/font/local";
 
 const silom = localFont({
@@ -33,10 +36,22 @@ const client = new ApolloClient({
 
 // const inter = Inter({ subsets: ["latin"] });
 
+const LanguageSync: React.FC = () => {
+  const { locale } = useRouter();
+  const setLanguage = useSetRecoilState(languageState);
+
+  useEffect(() => {
+    setLanguage((locale as "ja" | "en") || "ja");
+  }, [locale, setLanguage]);
+
+  return null;
+};
+
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <ApolloProvider client={client}>
       <RecoilRoot>
+        <LanguageSync />
         <main className={silom.className}>
           <Component {...pageProps} />
         </main>

--- a/view-user/src/pages/index.tsx
+++ b/view-user/src/pages/index.tsx
@@ -7,6 +7,8 @@ import { SubscribeListNumbersDocument } from "@/types/graphql";
 import type { SubscribeListNumbersSubscription } from "@/types/graphql";
 import { Layout, Loading, NumberCardLarge, NumberCardList } from "@/components";
 import { ja, en } from "@/locales";
+import { useRecoilValue } from "recoil";
+import { languageState } from "@/state/language";
 
 type BingoNumbers = SubscribeListNumbersSubscription["numbers"];
 
@@ -37,7 +39,7 @@ const getDisplayBingoNumbers = (
 
 const Page: NextPage = () => {
   const { pathname: pageName, locale } = useRouter();
-  const [language, setLanguage] = useState<string>(locale || "ja");
+  const language = useRecoilValue(languageState);
   const [isSortedAscending, setIsSortedAscending] = useState<boolean>(true);
   const { data, loading } = useSubscription(SubscribeListNumbersDocument);
   const t = locale === "ja" ? ja : en;
@@ -58,17 +60,10 @@ const Page: NextPage = () => {
     }
   }, [data]);
 
-  const updateLanguage = useCallback(() => {
-    setLanguage(locale || "ja");
-  }, [locale]);
 
   useEffect(() => {
     updateBingoNumbers();
   }, [updateBingoNumbers]);
-
-  useEffect(() => {
-    updateLanguage();
-  }, [updateLanguage]);
 
   const displayBingoNumbers = getDisplayBingoNumbers(
     isSortedAscending,
@@ -82,8 +77,6 @@ const Page: NextPage = () => {
         pageName={pageName}
         isSortedAscending={isSortedAscending}
         setIsSortedAscending={setIsSortedAscending}
-        language={language}
-        setLanguage={setLanguage}
       >
         <div className={styles.numberCardLarge}>
           {!isSortedAscending && displayBingoNumbers.large && (

--- a/view-user/src/pages/index.tsx
+++ b/view-user/src/pages/index.tsx
@@ -60,7 +60,6 @@ const Page: NextPage = () => {
     }
   }, [data]);
 
-
   useEffect(() => {
     updateBingoNumbers();
   }, [updateBingoNumbers]);

--- a/view-user/src/pages/prizes/index.tsx
+++ b/view-user/src/pages/prizes/index.tsx
@@ -51,6 +51,11 @@ const Page: NextPage = () => {
     }
   }, [subscription]);
 
+  // ルーターのロケール変更に追従して言語状態を更新
+  useEffect(() => {
+    setLanguage(locale || "ja");
+  }, [locale]);
+
   return (
     <>
       {loading && <Loading />}

--- a/view-user/src/pages/prizes/index.tsx
+++ b/view-user/src/pages/prizes/index.tsx
@@ -3,6 +3,7 @@ import { PrizeCardList, Loading, Layout } from "@/components";
 import { useRouter } from "next/router";
 import { useState, useEffect } from "react";
 import { ja, en } from "@/locales";
+import { useRecoilState } from "recoil";
 import { useQuery, useSubscription } from "@apollo/client";
 import {
   GetListPrizesDocument,
@@ -12,14 +13,12 @@ import type {
   GetListPrizesQuery,
   SubscribeListPrizesIsWonSubscription,
 } from "@/types/graphql";
-import { useRecoilState } from "recoil";
 import { bingoPrizeState } from "../../Atom/atom";
 
 const Page: NextPage = () => {
   const { pathname: pageName, locale } = useRouter();
   const t = locale === "ja" ? ja : en;
   const [bingoPrize, setBingoPrize] = useRecoilState(bingoPrizeState);
-  const [language, setLanguage] = useState<string>(locale || "ja");
   const [isSortedAscending, setIsSortedAscending] = useState<boolean>(true);
 
   const { data: query, loading } = useQuery<GetListPrizesQuery>(
@@ -34,12 +33,12 @@ const Page: NextPage = () => {
     if (query) {
       setBingoPrize(query?.prizes);
     }
-  }, [query]);
+  }, [query, setBingoPrize]);
 
   useEffect(() => {
     if (subscription && subscription.prizes) {
-      setBingoPrize((prizes) =>
-        prizes.map((prize) => {
+      setBingoPrize((prizes: GetListPrizesQuery["prizes"]) =>
+        prizes.map((prize: GetListPrizesQuery["prizes"][0]) => {
           const updatePrize = subscription.prizes.find(
             (
               subscriptionPrize: SubscribeListPrizesIsWonSubscription["prizes"][0],
@@ -49,12 +48,7 @@ const Page: NextPage = () => {
         }),
       );
     }
-  }, [subscription]);
-
-  // ルーターのロケール変更に追従して言語状態を更新
-  useEffect(() => {
-    setLanguage(locale || "ja");
-  }, [locale]);
+  }, [subscription, setBingoPrize]);
 
   return (
     <>
@@ -63,8 +57,6 @@ const Page: NextPage = () => {
         pageName={pageName}
         isSortedAscending={isSortedAscending}
         setIsSortedAscending={setIsSortedAscending}
-        language={language}
-        setLanguage={setLanguage}
       >
         <PrizeCardList BingoPrize={bingoPrize} />
       </Layout>

--- a/view-user/src/state/language.ts
+++ b/view-user/src/state/language.ts
@@ -1,0 +1,8 @@
+import { atom } from "recoil";
+
+export type SupportedLanguage = "ja" | "en";
+
+export const languageState = atom<SupportedLanguage>({
+  key: "languageState",
+  default: "ja",
+});


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->

# 対応Issue

<!-- 対応したIssue番号を記載 -->

- resolve #0

# 概要

<!-- 開発内容の概要を記載 -->
prize画面だとトグルボタンが反応しないから設定いじれない問題が起きていた。

# 実装詳細

<!-- 具体的な開発内容を記載 -->

# 画面スクリーンショット等

<!-- URLとともに貼る（なければ空欄でよい） -->

https://github.com/user-attachments/assets/293fe778-3e0b-413d-969c-f84837e0385c

# テスト項目

<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->

- [ ] prizeページでsettingsを開いてとグルボタンの切り替えができるか。言語選択を切り替えて変われば良さそう
- [ ]
- [ ]

# 備考

<!-- 実装していて困った箇所・質問など -->
