### PR TITLE
リアクションにエフェクトを付けた

### DIFF
--- a/view-user/src/components/Layout/Layout.tsx
+++ b/view-user/src/components/Layout/Layout.tsx
@@ -175,19 +175,17 @@ const Layout = (props: LayoutProps) => {
   } = useSurveyState(surveyEvent, hasShownSurvey, setHasShownSurvey);
 
   // スタンプ押下時の送信処理（短いクールダウンで二重送信を防止）
-  const handleReactionClick = async (name: string) => {
+  const handleReactionClick = (name: string) => {
     if (isStampSending) return;
-    try {
-      setActiveStampName(name);
-      setIsStampSending(true);
-      await createStampRecord({ variables: { name } });
-    } finally {
-      // 押下アニメの体感時間に合わせて解除（約0.8秒）
-      setTimeout(() => {
-        setIsStampSending(false);
-        setActiveStampName(null);
-      }, 800);
-    }
+    setActiveStampName(name);
+    setIsStampSending(true);
+    // 結果に関わらず固定時間で解除するためawait/エラーハンドリングは行わない
+    void createStampRecord({ variables: { name } });
+    // 押下アニメの体感時間に合わせて解除（約0.8秒）
+    setTimeout(() => {
+      setIsStampSending(false);
+      setActiveStampName(null);
+    }, 800);
   };
 
   // 設定内のアンケート回答ボタンの処理

--- a/view-user/src/components/Layout/Layout.tsx
+++ b/view-user/src/components/Layout/Layout.tsx
@@ -108,6 +108,10 @@ const Layout = (props: LayoutProps) => {
   const [navBarHeight, setNavBarHeight] = useState<string>();
   const navRef = useRef<HTMLDivElement>(null);
   const position: string = isReachIconVisible ? "29%" : "50%";
+  // スタンプ送信中フラグ（クールダウン中の連打防止）
+  const [isStampSending, setIsStampSending] = useState<boolean>(false);
+  // 直近に押したスタンプ名（押下中エフェクトの対象）
+  const [activeStampName, setActiveStampName] = useState<string | null>(null);
   const [createStampRecord] = useMutation<
     CreateOneStampTriggerMutation,
     CreateOneStampTriggerMutationVariables
@@ -144,12 +148,12 @@ const Layout = (props: LayoutProps) => {
     const storedSortOrder = localStorage.getItem("isSortedAscending");
     if (storedSortOrder !== null) {
       const isSortedAscending = storedSortOrder === "true";
-      props.setIsSortedAscending?.(isSortedAscending);
+      setIsSortedAscending?.(isSortedAscending);
       setIsSortOrderActive(isSortedAscending);
     } else {
       localStorage.setItem("isSortedAscending", "false");
     }
-  }, []);
+  }, [setIsSortedAscending]);
 
   // 初期設定を適用
   useEffect(() => {
@@ -170,9 +174,20 @@ const Layout = (props: LayoutProps) => {
     isSurveyActive,
   } = useSurveyState(surveyEvent, hasShownSurvey, setHasShownSurvey);
 
-  // リアクションアイコンがクリックされたときの処理
-  const handleReactionClick = (name: string) => {
-    createStampRecord({ variables: { name } });
+  // スタンプ押下時の送信処理（短いクールダウンで二重送信を防止）
+  const handleReactionClick = async (name: string) => {
+    if (isStampSending) return;
+    try {
+      setActiveStampName(name);
+      setIsStampSending(true);
+      await createStampRecord({ variables: { name } });
+    } finally {
+      // 押下アニメの体感時間に合わせて解除（約0.8秒）
+      setTimeout(() => {
+        setIsStampSending(false);
+        setActiveStampName(null);
+      }, 800);
+    }
   };
 
   // 設定内のアンケート回答ボタンの処理
@@ -257,10 +272,13 @@ const Layout = (props: LayoutProps) => {
   return (
     <div>
       {isReactionModalOpen && (
+        // 押下中は全スタンプボタンを無効化し、押したスタンプのみエフェクト適用
         <ReactionStampModal
           position={position}
           height={navBarHeight}
           images={images}
+          disabled={isStampSending}
+          activeName={activeStampName || undefined}
           onClick={handleReactionClick}
         />
       )}

--- a/view-user/src/components/common/ReactionStampModal/ReactionStampModal.module.css
+++ b/view-user/src/components/common/ReactionStampModal/ReactionStampModal.module.css
@@ -1,8 +1,10 @@
+/* モーダル整列用 */
 .horizontalCenter {
   display: flex;
   justify-content: center;
 }
 
+/* 吹き出し本体 */
 .bubble {
   width: 87.5vw;
   height: 50.9vw;
@@ -15,6 +17,7 @@
   z-index: 100;
 }
 
+/* 吹き出しの三角（アウトライン） */
 .bubble:before {
   content: "";
   position: absolute;
@@ -29,6 +32,7 @@
   filter: drop-shadow(0.546875vw 1.09375vw var(--main-color));
 }
 
+/* 吹き出しの三角（中身） */
 .bubble:after {
   content: "";
   position: absolute;
@@ -42,11 +46,13 @@
   margin-left: -2.1875vw;
 }
 
+/* 三角の左右位置をCSS変数で調整 */
 .bubble:before,
 .bubble:after {
   left: var(--bubble-left-position, 50%);
 }
 
+/* アイコンのグリッド配置 */
 .grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
@@ -57,6 +63,7 @@
   align-items: center;
 }
 
+/* アイコンボタンのベース */
 .iconButton {
   position: relative;
   border-radius: 50%;
@@ -68,10 +75,109 @@
   aspect-ratio: 1 / 1;
 }
 
+/* 押下中の柔らかいバウンス */
 .iconButton:active {
   animation: softBounce 1.5s infinite;
 }
 
+/* 直近に押されたアイコンに短いバウンス */
+.iconButton.active {
+  animation: softBounce 0.8s ease-in-out;
+}
+
+/* クールダウン中は操作無効＆半透明 */
+.iconButton.disabled {
+  pointer-events: none;
+  opacity: 0.6;
+}
+
+/* リップル（波紋） */
+.iconButton .ripple {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 20%;
+  height: 20%;
+  border-radius: 50%;
+  border: 0.5vw solid var(--main-color);
+  opacity: 0.7;
+  animation: rippleExpand 0.8s ease-out forwards;
+  pointer-events: none;
+}
+
+/* リップルの2発目タイミングずらし */
+.iconButton .ripple.delay {
+  animation-delay: 0.15s;
+}
+
+/* 押した画像が放射状に飛ぶ層のラッパー */
+.particles {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+/* 放射する1つ1つのパーティクル（中に画像を含む） */
+.particle {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 6.4vw;
+  height: 6.4vw;
+  transform: translate(-50%, -50%);
+  animation: burst 0.8s ease-out forwards;
+}
+
+/* パーティクル内の画像（塗り潰し） */
+.particleImg {
+  position: absolute;
+  inset: 0;
+}
+
+/* 10方向に飛ばすベクトルをnth-childで割り当て */
+.particle:nth-child(1) {
+  --tx: 0;
+  --ty: -18vw;
+}
+.particle:nth-child(2) {
+  --tx: 12vw;
+  --ty: -12vw;
+}
+.particle:nth-child(3) {
+  --tx: 18vw;
+  --ty: 0;
+}
+.particle:nth-child(4) {
+  --tx: 12vw;
+  --ty: 12vw;
+}
+.particle:nth-child(5) {
+  --tx: 0;
+  --ty: 18vw;
+}
+.particle:nth-child(6) {
+  --tx: -12vw;
+  --ty: 12vw;
+}
+.particle:nth-child(7) {
+  --tx: -18vw;
+  --ty: 0;
+}
+.particle:nth-child(8) {
+  --tx: -12vw;
+  --ty: -12vw;
+}
+.particle:nth-child(9) {
+  --tx: 8vw;
+  --ty: -16vw;
+}
+.particle:nth-child(10) {
+  --tx: -8vw;
+  --ty: 16vw;
+}
+
+/* 柔らかいバウンスのアニメーション */
 @keyframes softBounce {
   0% {
     transform: scale(1, 0.8);
@@ -84,5 +190,33 @@
   }
   100% {
     transform: scale(1, 0.8);
+  }
+}
+
+/* リップル拡大のアニメーション */
+@keyframes rippleExpand {
+  0% {
+    transform: translate(-50%, -50%) scale(0.5);
+    opacity: 0.9;
+  }
+  80% {
+    opacity: 0.4;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(3);
+    opacity: 0;
+  }
+}
+
+/* パーティクルが放射して消えるアニメーション */
+@keyframes burst {
+  0% {
+    transform: translate(-50%, -50%) scale(0.8);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(calc(-50% + var(--tx)), calc(-50% + var(--ty)))
+      scale(0.6);
+    opacity: 0;
   }
 }

--- a/view-user/src/components/common/ReactionStampModal/ReactionStampModal.tsx
+++ b/view-user/src/components/common/ReactionStampModal/ReactionStampModal.tsx
@@ -7,11 +7,14 @@ interface ImageProps {
   src: string;
   alt: string;
 }
+
 interface ReactionStampModalProps {
   position?: string;
   height?: string;
   images: ImageProps[];
   onClick: (name: string) => void;
+  disabled?: boolean;
+  activeName?: string;
 }
 
 const ReactionStampModal = (props: ReactionStampModalProps) => {
@@ -25,7 +28,9 @@ const ReactionStampModal = (props: ReactionStampModalProps) => {
       : "0px",
   };
 
+  // 押下禁止中は無視、許可時のみ親の送信処理を実行
   const handleClick = (name: string) => {
+    if (props.disabled) return;
     props.onClick(name);
   };
 
@@ -36,15 +41,44 @@ const ReactionStampModal = (props: ReactionStampModalProps) => {
         style={{ ...bubbleLeftPosition, ...modalBottom }}
       >
         <div className={styles.grid}>
-          {props.images.map((image) => (
-            <button
-              key={image.name}
-              className={styles.iconButton}
-              onClick={() => handleClick(image.name)}
-            >
-              <Image src={image.src} alt={image.alt} fill />
-            </button>
-          ))}
+          {props.images.map((image) => {
+            // 直近に押されたスタンプかどうか（派手エフェクトの対象）
+            const isActive = props.activeName === image.name;
+            return (
+              <button
+                key={image.name}
+                className={`${styles.iconButton} ${isActive ? styles.active : ""} ${
+                  props.disabled ? styles.disabled : ""
+                }`}
+                onClick={() => handleClick(image.name)}
+                disabled={props.disabled}
+                aria-disabled={props.disabled}
+                type="button"
+              >
+                {isActive && (
+                  <>
+                    {/* リップル（波紋）を2連で表示 */}
+                    <span className={styles.ripple} aria-hidden="true" />
+                    <span
+                      className={`${styles.ripple} ${styles.delay}`}
+                      aria-hidden="true"
+                    />
+                    {/* 押したスタンプ画像が放射状に飛ぶエフェクト */}
+                    <span className={styles.particles} aria-hidden="true">
+                      {Array.from({ length: 10 }).map((_, i) => (
+                        <span key={i} className={styles.particle}>
+                          <span className={styles.particleImg}>
+                            <Image src={image.src} alt="" fill />
+                          </span>
+                        </span>
+                      ))}
+                    </span>
+                  </>
+                )}
+                <Image src={image.src} alt={image.alt} fill />
+              </button>
+            );
+          })}
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->

# 対応Issue

<!-- 対応したIssue番号を記載 -->

- resolve #0

# 概要

<!-- 開発内容の概要を記載 -->
https://nut-m-e-g.slack.com/archives/C029KG3MAS3/p1756535099561359

リアクションボタン動かないけど、本番は稼働する感じ？

パラディン

ステージのスクリーンに表示されるのか

比嘉華

去年からその仕様だったけどuser画面でも何かしら押した感あるエフェクトとかあった方いいかな

よーーちゃん

ボタン押したエフェクト追加してその間はスタンプ押せないとかすると，スタンプ連投とかできなくなって，screen見やすいかも

# 実装詳細

<!-- 具体的な開発内容を記載 -->

# 画面スクリーンショット等

<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/d2701620-3c94-4673-8024-08c9c9c68213" />


https://github.com/user-attachments/assets/92e97768-4279-4dae-9b4d-41788c42d018



# テスト項目

<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->

- [ ] 動き良さげならおけまる。
- [ ] コードレビューも一応
- [ ]

# 備考

<!-- 実装していて困った箇所・質問など -->
