### PR TITLE
判定結果にmargin-topを追加

### DIFF
--- a/view-admin/src/components/common/JudgementModal/JudgementModal.module.css
+++ b/view-admin/src/components/common/JudgementModal/JudgementModal.module.css
@@ -640,4 +640,5 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  margin-top: 18px;
 }


### PR DESCRIPTION
# 概要

判定モーダル修正（ #357 ）でpaddingを削除したためにresultContainerにも影響が及んでいたための修正

# 画面スクリーンショット等

<!-- URLとともに貼る（なければ空欄でよい） -->

| Before | After |
| -- | -- |
| <img width="488" height="1055" alt="image" src="https://github.com/user-attachments/assets/df3057a6-1546-4b4c-81cd-b590cdff4a32" /> | <img width="488" height="1055" alt="image" src="https://github.com/user-attachments/assets/6c7cc354-0a82-4876-97cd-c8992d161136" />  |


# テスト項目

<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->

- [ ] 適切なmarginが設定されている

# 備考
変更１行です。