### PR TITLE
eventsテーブルをマイグレーションとして追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,18 +6,20 @@ run:
 down:
 	docker compose down
 
+# Apply database migrations first, then metadata to avoid temporary inconsistencies
 db-apply:
-	docker compose exec api hasura metadata apply
 	docker compose exec api hasura migrate apply --database-name default
+	docker compose exec api hasura metadata apply
 	docker compose exec api hasura metadata reload
 
 db-export:
 	docker compose exec api hasura metadata export
 	docker compose exec api hasura migrate create "auto" --from-server --database-name default
 
+# Production apply order aligned with best practice (migrations first)
 db-apply-prod:
-	docker compose -f docker-compose.prod.yml exec api hasura metadata apply
 	docker compose -f docker-compose.prod.yml exec api hasura migrate apply --database-name default
+	docker compose -f docker-compose.prod.yml exec api hasura metadata apply
 	docker compose -f docker-compose.prod.yml exec api hasura metadata reload
 
 run-prod:

--- a/api/migrations/default/1757258450288_ensure_events_table/down.sql
+++ b/api/migrations/default/1757258450288_ensure_events_table/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS public.events;

--- a/api/migrations/default/1757258450288_ensure_events_table/up.sql
+++ b/api/migrations/default/1757258450288_ensure_events_table/up.sql
@@ -1,0 +1,6 @@
+-- Ensure events table exists (added after prod hotfix)
+CREATE TABLE IF NOT EXISTS public.events (
+  id BIGSERIAL PRIMARY KEY,
+  survey_url text NOT NULL,
+  is_survey_active boolean NOT NULL DEFAULT false
+);


### PR DESCRIPTION
# 対応Issue
- デプロイ時に不整合が発生したため

# 概要
本番で手動作成された `events` テーブルを正式なマイグレーションとして管理下に置き、以後の環境差異を防止。  
併せて Hasura 適用順序を `migrate → metadata` に変更し一時的な不整合警告の発生を回避。

# 実装詳細
- 追加: 1757258450288_ensure_events_table
  - up.sql: `CREATE TABLE IF NOT EXISTS public.events (...)`
  - `down.sql`: `DROP TABLE IF EXISTS public.events;`
  - 既存マイグレーションに後追い追記せず、新規マイグレーションとして追加
- 修正: Makefile
  - `db-apply` / `db-apply-prod` の順序を
    - (旧) metadata apply → migrate → reload
    - (新) migrate → metadata apply → reload
  - コメント追加で意図を明示

# 画面スクリーンショット等
（不要 / なし）

# テスト項目
- [ ] ローカル: `make run` 後 `hasura migrate status` で新マイグレーションが Applied
- [ ] GraphQL `{ events { id surveyUrl isSurveyActive } }` が 200 / エラーなし
- [ ] 既に `events` が存在する環境（本番）でも再適用時エラーが出ない（`IF NOT EXISTS`）
- [ ] 他既存テーブルに影響がない（差分なし）
- [ ] Makefile の順序変更で初回起動時に metadata 不整合が出ない