### PR TITLE
break-glass専用管理者を廃止

### DIFF
--- a/Dockerfile.cloudflare
+++ b/Dockerfile.cloudflare
@@ -5,6 +5,7 @@ FROM node:26.2.0-bookworm-slim@sha256:e89172f5e6154ba212269866bf3fbadbca8eb7901e
 ENV NEXT_TELEMETRY_DISABLED=1
 WORKDIR /app
 RUN apt-get update \
+  && apt-get upgrade --yes \
   && apt-get install --yes --no-install-recommends ca-certificates libc++1 \
   && rm -rf /var/lib/apt/lists/*
 
@@ -32,9 +33,13 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN pnpm build
 
-FROM builder AS development
+FROM base AS development
+COPY --from=builder --chown=node:node /app /app
+RUN rm -rf /usr/local/lib/node_modules/npm \
+  && rm -f /usr/local/bin/npm /usr/local/bin/npx
+USER node
 EXPOSE 8787
-CMD ["pnpm", "exec", "wrangler", "dev", "--ip", "0.0.0.0", "--port", "8787"]
+CMD ["node", "node_modules/wrangler/bin/wrangler.js", "dev", "--ip", "0.0.0.0", "--port", "8787"]
 
 # Export with `docker buildx build --target export --output type=local,dest=. ...`.
 # The host receives only `out/`; Next.js itself never builds on the host.

--- a/docs/cloudflare-migration-plan.md
+++ b/docs/cloudflare-migration-plan.md
@@ -435,8 +435,8 @@ degrade は次の順で適用する。
   deploy担当と復旧担当をnamed memberとして招待する。
 - 団体account IDをreview済み設定へ固定し、production zone、R2、Access、Turnstile、custom domain、
   WAF、backup lifecycleを新設する。個人account上の旧`production` resourceへ昇格しない。
-- 当日管理者約10名と別人のbreak-glass管理者をexact-email Access policyとWorker allowlistへ登録し、
-  private browser、MFA、Access audit、未登録identity拒否を確認する。
+- 当日管理者約10名（通常操作と緊急対応を担うインフラ代表者を含む）をexact-email Access policyと
+  Worker allowlistへ登録し、private browser、Access audit、未登録identity拒否を確認する。
 - 団体productionと個人stagingのaccount分離を`whoami`、R2 list、deployment listで確認する。
 - 同一release SHAをstaging証跡から団体productionへ昇格し、production smoke、version ID、
   generation、snapshot keyを記録してからDNSをcutoverする。

--- a/docs/cloudflare-operations.md
+++ b/docs/cloudflare-operations.md
@@ -113,19 +113,18 @@ staging証跡から昇格します。
 ## 当日管理者の登録・変更
 
 当日管理者はCloudflare account memberではありません。各自のemailでAccessへloginし、Access policyと
-Worker `ADMIN_EMAILS`の二重allowlistを通過します。約10名の通常管理者に加え、通常担当者と別人の
-named break-glass管理者を1名指定します。共有address、mailing list、service token、domain全体、
-Everyone、Bypassは使用しません。
+Worker `ADMIN_EMAILS`の二重allowlistを通過します。約10名のnamed管理者を登録します。インフラ代表者は
+通常操作と緊急対応を同じ個人identityで担い、break-glass専用identity/policyは設けません。共有address、
+mailing list、service token、domain全体、Everyone、Bypassは使用しません。
 
 ### 名簿を準備してWorker allowlistへ反映する
 
 名簿は承認済みのteam secret storeを正本とし、作業端末ではmode `600`のGit管理外ファイルだけを
-一時利用します。`administrators`は1〜19名、`breakGlassAdministrator`は別emailの1名です。
+一時利用します。`administrators`は1〜20名のnamed管理者です。
 
 ```json
 {
-  "administrators": ["admin1@organization.example", "admin2@organization.example"],
-  "breakGlassAdministrator": "recovery-admin@organization.example"
+  "administrators": ["admin1@organization.example", "admin2@organization.example"]
 }
 ```
 
@@ -136,22 +135,18 @@ mise run cloudflare:admins:set .cloudflare/admin-roster.production.json
 stat -c '%a %n' .cloudflare/admin-roster.production.json .cloudflare.deploy.production.env
 ```
 
-taskは形式、小文字、重複、人数、placeholder、break-glassの分離、共有owner addressの混入、
+taskは形式、小文字、重複、人数、placeholder、共有owner addressの混入、
 両ファイルの権限を検査し、`.cloudflare.deploy.production.env`の`ADMIN_EMAILS`だけをatomicに
 更新します。emailはterminalへ出さず、人数と名簿SHA-256を出力します。SHA-256をchange recordへ
 記録し、名簿ファイルは作業後に削除します。
 
 ### Access policyを同じ名簿へ合わせる
 
-1. production `/admin*` applicationの通常Allow policyへ`administrators`の各emailをexact-emailで
-   登録する。
-2. `breakGlassAdministrator`だけの別Allow policyを作る。Independent MFAの
-   `Custom MFA settings`を必須にし、MFA session durationを30分以下にする。
-3. policy previewで対象email以外がmatchしないこと、Admin/Screen applicationのAUDが異なることを
+1. production `/admin*` applicationのAllow policyへ`administrators`の各emailをexact-emailで登録する。
+2. policy previewで対象email以外がmatchしないこと、Admin/Screen applicationのAUDが異なることを
    確認する。
-4. 各通常管理者がprivate browserで`/admin`を開き、少なくとも代表者1名が可逆mutationを行う。
-   break-glass担当者もprivate browserでMFAを完了し、Access auditに個人emailの成功eventが残ることを
-   確認する。未登録identityの拒否も記録する。
+3. 各管理者がprivate browserで`/admin`を開き、少なくとも代表者1名が可逆mutationを行う。
+   インフラ代表者の個人emailによる成功eventと未登録identityの拒否をAccess auditで確認する。
 
 初回構築ではAccess policyとWorker allowlistを公開前に同時設定します。運用中の追加は
 `Worker allowlistへ追加・deploy → Access exact-emailへ追加`、削除は
@@ -241,7 +236,7 @@ node scripts/init-cloudflare-deploy-env.mjs --env production --force
 ```
 
 初回Worker構築前のproductionは前章の`install -m 600`と管理者名簿taskを使います。stagingも
-exampleをmode `600`で導入します。`ADMIN_EMAILS`は2〜20件、`SCREEN_EMAILS`は1〜10件の
+exampleをmode `600`で導入します。`ADMIN_EMAILS`は1〜20件、`SCREEN_EMAILS`は1〜10件の
 一意な小文字email JSON配列です。空配列、予約済みplaceholder domain、共有owner address、
 review済み公開設定と異なる値はdeploy taskが拒否します。
 
@@ -396,8 +391,6 @@ productionへ進みません。
 7. screen socketが30分後に`1012`で閉じ、JWT再検証後だけ再接続する。
 8. backup bucketをpublic URLから読めない。
 9. Access audit、Worker/DO Analytics、WAF Events、当日snapshotをoperatorが閲覧できる。
-10. 通常operatorと別identityのnamed break-glass管理者がprivate browserでMFA loginできる。
-    専用policyのMFA session durationが30分以下で、Access auditに成功eventが残ることも確認する。
 
 Cloudflare Analyticsで確認した最大snapshot CPU p95を引数へ渡し、各質問へ実確認後だけ`yes`と入力します。
 
@@ -432,7 +425,7 @@ mise run cloudflare:smoke:finalize
 ./scripts/cloudflare-wrangler.sh --target production deployments list --env=''
 ```
 
-stagingと同じ手動10項目をproductionでも確認します。最終record
+stagingと同じ手動9項目をproductionでも確認します。最終record
 `.cloudflare/deployments/production-<SHA>.json`にはactive production version ID、Git SHA、operator、
 実施時刻、自動・手動結果が入ります。staging/production recordとdeploy前後のversion IDをteamの
 change recordへ添付します。`.cloudflare/`はGit管理外であり、端末だけを恒久保管先にしません。
@@ -568,7 +561,7 @@ production昇格時は次を満たす24時間以内のstaging recordが必要で
 - 公開HTTP、画像、Access redirect、WebSocketの自動smokeがすべて成功
 - 1000/1000 socket ready、complete broadcast 5回以上、HTTP/WS failure 0
 - 最大snapshot 3回、integrity一致、active pointer不変、R2保存、Worker CPU p95 10 ms以下
-- Access identity、Turnstile、画像upload、30分再認証、backup非公開、観測、break-glassの手動確認
+- Access identity、Turnstile、画像upload、30分再認証、backup非公開、観測の手動確認
 
 記録は`.cloudflare/deployments/`へ生成した後、staging/productionのversion ID、Git SHA、operator、
 時刻とともにteamのchange recordへ添付します。口頭確認やterminal scrollbackだけを証跡にしません。

--- a/mise.toml
+++ b/mise.toml
@@ -48,12 +48,12 @@ run = "node scripts/init-cloudflare-deploy-env.mjs --env staging"
 
 [tasks."cloudflare:admins:set"]
 description = "Validate a private production administrator roster and update the deploy environment"
-usage = 'arg "<roster>" help="Mode-600 JSON roster with named and break-glass administrators"'
+usage = 'arg "<roster>" help="Mode-600 JSON roster with named administrators"'
 run = 'node scripts/set-cloudflare-admins.mjs --env production --roster "$usage_roster"'
 
 [tasks."cloudflare:admins:set:staging"]
 description = "Validate a private staging administrator roster and update the deploy environment"
-usage = 'arg "<roster>" help="Mode-600 JSON roster with named and break-glass administrators"'
+usage = 'arg "<roster>" help="Mode-600 JSON roster with named administrators"'
 run = 'node scripts/set-cloudflare-admins.mjs --env staging --roster "$usage_roster"'
 
 [tasks."cloudflare:smoke"]

--- a/scripts/cloudflare-smoke.mjs
+++ b/scripts/cloudflare-smoke.mjs
@@ -174,7 +174,7 @@ const websocketEvidence = await new Promise((resolve, reject) => {
 
 const whoami = wranglerJson("whoami");
 const record = {
-  schemaVersion: 1,
+  schemaVersion: 2,
   environment: target,
   releaseSha,
   workerVersionId,
@@ -205,7 +205,6 @@ const record = {
     screenReauthentication: false,
     backupPrivate: false,
     observability: false,
-    breakGlass: false,
   },
   load: null,
   snapshot: null,

--- a/scripts/deploy-cloudflare.sh
+++ b/scripts/deploy-cloudflare.sh
@@ -196,9 +196,9 @@ const reservedEmailDomainPattern =
   /@(?:example\.(?:com|net|org)|[^@]+\.(?:example|invalid|test)|localhost)$/i;
 const requirements = {
   ADMIN_EMAILS: {
-    minimum: 2,
+    minimum: 1,
     maximum: 20,
-    purpose: "named event administrators including a distinct break-glass administrator",
+    purpose: "named event administrators",
   },
   SCREEN_EMAILS: {
     minimum: 1,

--- a/scripts/finalize-cloudflare-smoke.mjs
+++ b/scripts/finalize-cloudflare-smoke.mjs
@@ -19,8 +19,8 @@ for (let index = 0; index < args.length; index += 2) {
 if (!options.has("draft")) throw new Error("--draft is required");
 
 const draft = JSON.parse(await readFile(options.get("draft"), "utf8"));
-if (draft.schemaVersion !== 1 || !new Set(["production", "staging"]).has(draft.environment)) {
-  throw new Error("Draft must be a production or staging schemaVersion 1 smoke record");
+if (draft.schemaVersion !== 2 || !new Set(["production", "staging"]).has(draft.environment)) {
+  throw new Error("Draft must be a production or staging schemaVersion 2 smoke record");
 }
 execFileSync("./scripts/check-cloudflare-operator.sh", ["--env", draft.environment], {
   stdio: "inherit",
@@ -79,10 +79,6 @@ const prompts = [
   [
     "observability",
     "Operator opened Access audit, Worker/DO Analytics, WAF Events, and today's snapshot",
-  ],
-  [
-    "breakGlass",
-    "A distinct named break-glass administrator completed MFA in a private browser under a policy with a session duration of 30 minutes or less, and the successful event appeared in Access audit",
   ],
 ];
 const readline = createInterface({ input: process.stdin, output: process.stdout });

--- a/scripts/set-cloudflare-admins.mjs
+++ b/scripts/set-cloudflare-admins.mjs
@@ -54,24 +54,23 @@ const projectConfig = Object.fromEntries(
 );
 
 const roster = JSON.parse(await readFile(rosterPath, "utf8"));
-const expectedKeys = ["administrators", "breakGlassAdministrator"];
+const expectedKeys = ["administrators"];
 if (
   roster === null ||
   typeof roster !== "object" ||
   Array.isArray(roster) ||
   Object.keys(roster).toSorted().join("\n") !== expectedKeys.toSorted().join("\n") ||
-  !Array.isArray(roster.administrators) ||
-  typeof roster.breakGlassAdministrator !== "string"
+  !Array.isArray(roster.administrators)
 ) {
-  throw new Error('Roster must be {"administrators":["..."],"breakGlassAdministrator":"..."}');
+  throw new Error('Roster must be {"administrators":["..."]}');
 }
 
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-const administrators = [...roster.administrators, roster.breakGlassAdministrator];
+const administrators = roster.administrators;
 const reservedEmailDomainPattern =
   /@(?:example\.(?:com|net|org)|[^@]+\.(?:example|invalid|test)|localhost)$/i;
 if (
-  administrators.length < 2 ||
+  administrators.length < 1 ||
   administrators.length > 20 ||
   administrators.some(
     (email) =>
@@ -83,9 +82,7 @@ if (
   ) ||
   new Set(administrators).size !== administrators.length
 ) {
-  throw new Error(
-    "Roster must contain 1-19 unique lowercase named administrators plus one distinct break-glass administrator",
-  );
+  throw new Error("Roster must contain 1-20 unique lowercase named administrators");
 }
 if (
   target === "production" &&
@@ -114,14 +111,7 @@ await chmod(temporaryPath, 0o600);
 await rename(temporaryPath, deployEnvPath);
 
 const rosterHash = createHash("sha256")
-  .update(
-    JSON.stringify({
-      administrators: canonicalAdministrators.filter(
-        (email) => email !== roster.breakGlassAdministrator,
-      ),
-      breakGlassAdministrator: roster.breakGlassAdministrator,
-    }),
-  )
+  .update(JSON.stringify({ administrators: canonicalAdministrators }))
   .digest("hex");
 console.log(
   `Updated ${deployEnvPath}: ${canonicalAdministrators.length} named administrators; roster SHA-256 ${rosterHash}. Email addresses were not printed.`,

--- a/scripts/verify-cloudflare-smoke-record.mjs
+++ b/scripts/verify-cloudflare-smoke-record.mjs
@@ -22,7 +22,7 @@ const requireTrueFields = (value, fields, label) => {
   }
 };
 
-if (record.schemaVersion !== 1) fail("schemaVersion must be 1");
+if (record.schemaVersion !== 2) fail("schemaVersion must be 2");
 if (record.environment !== "staging") fail("environment must be staging");
 if (record.releaseSha !== releaseSha) fail("releaseSha does not match the production candidate");
 if (record.workerVersionId !== workerVersionId) {
@@ -62,7 +62,6 @@ requireTrueFields(
     "screenReauthentication",
     "backupPrivate",
     "observability",
-    "breakGlass",
   ],
   "manual",
 );


### PR DESCRIPTION
## Decision

インフラ代表者が通常操作と緊急対応を同じnamed identityで担う運用へ変更し、break-glass専用identity/policyを廃止します。

## Change

- private rosterを `{ "administrators": [...] }` の単一listへ変更
- `ADMIN_EMAILS` を1〜20名で検証
- 専用break-glass Access policy/MFA手順をrunbookから削除
- smoke evidenceをschemaVersion 2・手動9項目へclean cutover
- legacy schemaVersion 1 recordはproduction昇格guardで拒否

## Verification

- production roster task: 1 named administratorで成功、email非表示、SHA-256出力
- private production env: mode 600、Admin 1名、Screen 2名、review済み公開座標一致
- Admin/Screen Access policy: exact-emailのみ、Everyone/Domain/Bypassなし
- schemaVersion 2 record受理、legacy schemaVersion 1拒否を実行確認
- `pnpm fmt:check`
- `pnpm lint`
- `pnpm typecheck`（`next typegen`後）
- `pnpm test` — 42 tests passed
- `pnpm secrets:check`

専用の別identityが失われるため、単一インフラ代表者のcredential障害が緊急対応能力へ直結する運用リスクを受容する変更です。